### PR TITLE
Add hydrograph plots to front end

### DIFF
--- a/src/eddie_floodresilience/blueprint.py
+++ b/src/eddie_floodresilience/blueprint.py
@@ -1,12 +1,12 @@
 """Endpoints and flask configuration for the Flood Resilience Digital Twin"""
 import os
 import pathlib
+from http.client import OK
 
-from flask import Blueprint
+from flask import Blueprint, Response, make_response
 
 from eddie.check_celery_alive import check_celery_alive
-
-from src.eddie_floodresilience import hydrological_and_hydrodynamic_service as hh_service
+from src.eddie_floodresilience import hydrological_and_hydrodynamic_service as hh_service, tasks
 
 os.environ.pop("Path", None)
 # See issue https://github.com/GeospatialResearch/eddie_floodresilience/issues/1 for reason behind disabled QA
@@ -39,3 +39,29 @@ def wps() -> Service:
         The PyWPS WebProcessing Service instance
     """
     return service
+
+
+@blueprint.route('/hydrographs/scenarios/<int:scenario_id>/features/<string:feature_id>')
+@check_celery_alive
+def retrieve_hydrograph(scenario_id: int, feature_id: str) -> Response:
+    """
+    Find hydrograph data for the given scenario and feature as CSV format.
+
+    Parameters
+    ----------
+    scenario_id: str
+        The flood model output ID to find query hydrograph data for.
+    feature_id: str
+        The FID of the specific injection point to query hydrograph data for.
+
+    Returns
+    -------
+    Response
+        Response with body containing hydrograph data in CSV format.
+    """
+    get_hydrograph_task = tasks.read_hydrograph_data.delay(scenario_id, feature_id)
+    hydrograph_data = get_hydrograph_task.get()
+
+    response = make_response(hydrograph_data, OK)
+    response.content_type = "text/csv"
+    return response

--- a/src/eddie_floodresilience/config.py
+++ b/src/eddie_floodresilience/config.py
@@ -44,6 +44,11 @@ class EnvVariable(EnvVarBase):  # pylint: disable=too-few-public-methods
 
     IS_GEOSERVER_ACTIVE = EnvVarBase._get_bool_env_variable("IS_GEOSERVER_ACTIVE", True)
 
+    BACKEND_URL = EnvVarBase._get_env_variable(
+        "BACKEND_URL",
+        default=f'{EnvVarBase._get_env_variable("BACKEND_HOST")}:{EnvVarBase._get_env_variable("BACKEND_PORT")}',
+    )
+
     # NewZealidar config that we must ensure have values.
     _LIDAR_DIR = EnvVarBase._get_env_variable("LIDAR_DIR")
     _DEM_DIR = EnvVarBase._get_env_variable("DEM_DIR")

--- a/src/eddie_floodresilience/flood_model/bgflood/bgflood_simulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/bgflood/bgflood_simulations_generator.py
@@ -123,7 +123,7 @@ class BGFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
         return output_folder_path
 
     # pylint: disable=useless-type-doc,useless-param-doc
-    def flood_model_simulations_generator(self, _output_dir: Path | None) -> int:
+    def flood_model_simulations_generator(self, _output_dir: Path | None) -> Path:
         """
         Generate flood simulations by running flood model
 
@@ -137,8 +137,8 @@ class BGFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
 
         Returns
         -------
-        int
-            The Flood Model output ID
+        Path
+            The Flood Model maximum extents raster file
         """
         # Set up path to log file
         log_file_path = self.flood_model_path / "simulation_log.log"
@@ -178,8 +178,8 @@ class BGFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
             )
         output_nc = output_folder_path / "output.nc"
         output_tif = convert_nc_to_gtiff(output_nc)
-        model_output_id = self.serve_flood_model_outputs(output_tif)
-        return model_output_id
+
+        return output_tif
 
     def flood_model_executor(self) -> int:
         """
@@ -207,7 +207,7 @@ class BGFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
             self.precipitation_data_for_flood_model_generator()
 
             # Generate simulations by running flood model
-            model_output_id = self.flood_model_simulations_generator(None)
+            max_gtiff = self.flood_model_simulations_generator(None)
 
         # This 'elif' includes 3 and 4
         elif self.polygons is not None or self.vectors is None:
@@ -218,7 +218,7 @@ class BGFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
             self.parameter_files_for_flood_model_generator()
 
             # Generate simulations by running flood model
-            model_output_id = self.flood_model_simulations_generator(None)
+            max_gtiff = self.flood_model_simulations_generator(None)
 
         # This 'else' includes 2
         else:
@@ -226,5 +226,8 @@ class BGFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
             self.parameter_files_for_flood_model_generator()
 
             # Generate simulations by running flood model
-            model_output_id = self.flood_model_simulations_generator(None)
+            max_gtiff = self.flood_model_simulations_generator(None)
+
+        # Add the results to the database and geoserver
+        model_output_id = self.serve_flood_model_outputs(max_gtiff)
         return model_output_id

--- a/src/eddie_floodresilience/flood_model/bgflood/bgflood_simulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/bgflood/bgflood_simulations_generator.py
@@ -230,4 +230,5 @@ class BGFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
 
         # Add the results to the database and geoserver
         model_output_id = self.serve_flood_model_outputs(max_gtiff)
+        self.serve_injection_points(model_output_id)
         return model_output_id

--- a/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
@@ -23,6 +23,7 @@ from datetime import datetime
 import logging
 
 import geopandas as gpd
+import pandas as pd
 from shapely.geometry import box
 
 from eddie import geoserver
@@ -220,3 +221,54 @@ class BaseFloodModelSimulationsGenerator(ABC):
         serve_model.create_viridis_style_if_not_exists()
 
         return model_output_id
+
+    def serve_injection_points(self, model_output_id: int) -> None:
+        # Read injection point files
+        flow_df_path = self.flood_model_path / "injection_points_flow.csv"
+        flow_df = pd.read_csv(flow_df_path)
+        points_path = self.flood_model_path / "injection_points.shp"
+        injection_points = gpd.read_file(points_path)
+
+        # Transform flow_df into one-row-per-point structure, matching `injection_points`.
+        flow_transformed = flow_df.T
+        # Name columns based on timestamp
+        flow_transformed.columns = flow_transformed.iloc[0]
+        # Drop timestamp row
+        flow_transformed = flow_transformed.iloc[1:]
+        # Match the index name to its true representation
+        flow_transformed = flow_transformed.rename_axis("FID")
+
+        # Merge the two datasets, so geometry and flow data are in one
+        flow_points = injection_points.merge(flow_transformed, on="FID").copy(deep=True)
+
+        # Further transform into narrow form, with one column listing timestamps and one column listing flows,
+        # while still retaining one-row-per-point.
+        # This is the form expected for visualization in the front-end.
+
+        static_cols = ["geometry", "FID"]
+        time_cols = [col for col in flow_points.columns if col not in static_cols]
+        narrow_df = flow_points[static_cols]
+        # Correctly set the geomery, since it may not be missing
+        narrow_df = narrow_df.set_geometry("geometry")
+        # Add the full list of datetimes to each row
+        narrow_df["datetimes"] = [time_cols] * len(narrow_df)
+        # Add a list of flows to each row, parallel to the datetimes.
+        narrow_df["flows"] = flow_points[time_cols].values.tolist()
+
+        # Add flood_model_id so we can select by it in database queries.
+        narrow_df["model_output_id"] = model_output_id
+
+        # Set up geoserver workspace and store
+        db_name = EnvVariable.POSTGRES_DB
+        workspace_name = f"{db_name}-flood-model-inputs"
+        geoserver.create_workspace_if_not_exists(workspace_name)
+        store_name = geoserver.create_main_db_store(workspace_name)
+
+        # Append the hydrograph data to the database and serve it
+        engine = setup_environment.get_database()
+        with engine.connect() as conn:
+            # Append the data to the database
+            table_name = "injection_points"
+            narrow_df.to_postgis(table_name, conn, if_exists="append", index=False)
+            # Serve the data
+            geoserver.create_datastore_layer(conn, workspace_name, store_name, table_name)

--- a/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
@@ -223,6 +223,14 @@ class BaseFloodModelSimulationsGenerator(ABC):
         return model_output_id
 
     def serve_injection_points(self, model_output_id: int) -> None:
+        """
+        Add injection points for flood model to database and geoserver for serving.
+
+        Parameters
+        ----------
+        model_output_id : int
+            The flood model output ID to associate the injection points with.
+        """
         # Read injection point files
         flow_df_path = self.flood_model_path / "injection_points_flow.csv"
         flow_df = pd.read_csv(flow_df_path)

--- a/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
@@ -152,7 +152,7 @@ class BaseFloodModelSimulationsGenerator(ABC):
         """
 
     @abstractmethod
-    def flood_model_simulations_generator(self, output_dir: Path) -> int:
+    def flood_model_simulations_generator(self, output_dir: Path) -> Path:
         """
         Generate flood simulations by running flood model
 
@@ -163,8 +163,8 @@ class BaseFloodModelSimulationsGenerator(ABC):
 
         Returns
         -------
-        int
-            The Flood Model output ID
+        Path
+            The Flood Model maximum extents raster file
         """
 
     @abstractmethod

--- a/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
@@ -256,7 +256,7 @@ class BaseFloodModelSimulationsGenerator(ABC):
         static_cols = ["geometry", "FID"]
         time_cols = [col for col in flow_points.columns if col not in static_cols]
         narrow_df = flow_points[static_cols]
-        # Correctly set the geomery, since it may not be missing
+        # Correctly set the geomery, since it may be missing
         narrow_df = narrow_df.set_geometry("geometry")
         # Add the full list of datetimes to each row
         narrow_df["datetimes"] = [time_cols] * len(narrow_df)

--- a/src/eddie_floodresilience/flood_model/lisflood/lisflood_simulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/lisflood/lisflood_simulations_generator.py
@@ -216,4 +216,5 @@ class LisFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
 
         # Add the results to the database and geoserver
         model_output_id = self.serve_flood_model_outputs(max_gtiff)
+        self.serve_injection_points(model_output_id)
         return model_output_id

--- a/src/eddie_floodresilience/flood_model/lisflood/lisflood_simulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/lisflood/lisflood_simulations_generator.py
@@ -103,7 +103,7 @@ class LisFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
         output_dir = parameters_files_generator.parameter_files_generator()
         return output_dir
 
-    def flood_model_simulations_generator(self, output_dir: Path) -> int:
+    def flood_model_simulations_generator(self, output_dir: Path) -> Path:
         """
         Generate flood simulations by running flood model
 
@@ -114,8 +114,8 @@ class LisFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
 
         Returns
         -------
-        int
-            The Flood Model output ID
+        Path
+            The Flood Model maximum extents raster file
         """
         # Set up path to log file
         log_file_path = self.flood_model_path / "simulation_log.log"
@@ -159,8 +159,7 @@ class LisFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
         max_gtiff = output_dir / f"{output_dir.name}-{time}-out.tif"
         serve_model.asc_to_gtiff(output_asc, max_gtiff)
 
-        model_output_id = self.serve_flood_model_outputs(max_gtiff)
-        return model_output_id
+        return max_gtiff
 
     def flood_model_executor(self) -> int:
         """
@@ -191,7 +190,7 @@ class LisFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
             output_dir = self.parameter_files_for_flood_model_generator()
 
             # Generate simulations by running flood model
-            model_output_id = self.flood_model_simulations_generator(output_dir)
+            max_gtiff = self.flood_model_simulations_generator(output_dir)
 
         # This 'elif' includes 3 and 4
         elif self.polygons is not None or self.vectors is None:
@@ -202,7 +201,7 @@ class LisFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
             output_dir = self.parameter_files_for_flood_model_generator()
 
             # Generate simulations by running flood model
-            model_output_id = self.flood_model_simulations_generator(output_dir)
+            max_gtiff = self.flood_model_simulations_generator(output_dir)
 
         # This 'else' includes 2
         else:
@@ -213,5 +212,8 @@ class LisFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
             output_dir = self.parameter_files_for_flood_model_generator()
 
             # Generate simulations by running flood model
-            model_output_id = self.flood_model_simulations_generator(output_dir)
+            max_gtiff = self.flood_model_simulations_generator(output_dir)
+
+        # Add the results to the database and geoserver
+        model_output_id = self.serve_flood_model_outputs(max_gtiff)
         return model_output_id

--- a/src/eddie_floodresilience/flood_model/templates/plot_infobox_template.html
+++ b/src/eddie_floodresilience/flood_model/templates/plot_infobox_template.html
@@ -1,0 +1,13 @@
+<!--Template used for TerriaJS to display a plot, especially for a vector feature.-->
+<!-- Double-escaped so that after python string formatting it is still mustache formatted. -->
+<h4>
+  {plot_title}
+</h4>
+<chart
+    src="{csv_src}"
+    title="{plot_title}"
+    x-column="{x_axis}"
+    y-column="{y_axis}"
+    column-units="{y_units}"
+>
+</chart>

--- a/src/eddie_floodresilience/flood_model/templates/plot_infobox_template.html
+++ b/src/eddie_floodresilience/flood_model/templates/plot_infobox_template.html
@@ -1,5 +1,4 @@
 <!--Template used for TerriaJS to display a plot, especially for a vector feature.-->
-<!-- Double-escaped so that after python string formatting it is still mustache formatted. -->
 <h4>
   {plot_title}
 </h4>

--- a/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
@@ -18,9 +18,12 @@
 """Serves data for WFlow scenarios, such as landcover and catchment boundaries."""
 
 import logging
+from ast import literal_eval
+from io import StringIO
 from pathlib import Path
 
 import geopandas as gpd
+import pandas as pd
 import rioxarray as rxr
 
 from eddie import geoserver as gs
@@ -153,3 +156,54 @@ class WflowServeDataGenerator:
             table_name = "wflow_catchment_boundary"
             catchment_poly.to_postgis(table_name, conn, if_exists="append", index=False)
             gs.create_datastore_layer(conn, workspace_name, data_store, table_name)
+
+
+def get_hydrograph_csv(flood_model_id: int, injection_point_feature_id: str) -> str:
+    """
+    Query the database for hydrograph data for an injection point and format it as CSV.
+
+    Parameters
+    ----------
+    flood_model_id: str
+        The flood model output ID to find query hydrograph data for.
+    injection_point_feature_id: str
+        The FID of the specific injection point to query hydrograph data for.
+
+    Returns
+    -------
+    str
+        CSV formatted hydrograph data for an injection point.
+    """
+    query = """
+            SELECT datetimes, flows
+            FROM injection_points
+            WHERE model_output_id = %(model_output_id)s
+              AND "FID" = %(FID)s
+            """
+    params = {
+        "model_output_id": flood_model_id,
+        "FID": injection_point_feature_id,
+    }
+    # Read the data with datetimes and flows each in a list within one row.
+    engine = setup_environment.get_database()
+    with engine.connect() as conn:
+        wide_form_df = pd.read_sql(query, conn, params=params)
+
+    # Correct types, columns as lists
+    wide_form_df.datetimes = wide_form_df.datetimes.apply(literal_eval)
+    wide_form_df.flows = wide_form_df.flows.apply(literal_eval)
+
+    # Expand the lists into long form df
+    long_df = wide_form_df.explode(["datetimes", "flows"]).drop_duplicates()
+    # Correct datetimes type object -> pd.datetime
+    db_date_format = "%Y-%m-%d %H:%M:%S"
+    long_df.datetimes = pd.to_datetime(long_df.datetimes, format=db_date_format)
+
+    # Format the column names ready for display
+    long_df = long_df.rename(columns={"datetimes": "Time", "flows": "Flow"})
+
+    # Format data frame into a Comma Separated Values (CSV) string
+    buffer = StringIO()
+    long_df.to_csv(buffer, index=False, date_format="%Y-%m-%dT%H:%M:%SZ")
+    csv_string = buffer.getvalue()
+    return csv_string

--- a/src/eddie_floodresilience/hydrological/wflow_simulations_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_simulations_generator.py
@@ -18,6 +18,7 @@
 """Runs Wflow model simulations"""
 
 import logging
+import shutil
 import subprocess
 from pathlib import Path
 from datetime import datetime
@@ -219,10 +220,16 @@ class WflowSimulationsGenerator:
                 "bbox": self.flood_aoi_boundary
             })
 
+            wflow_test_full_dir = self.wflow_model_path / "wflow_test_full"
+            # Force override is turned off for performance, so we must manually remove the run_default dir if required.
+            run_default_dir = wflow_test_full_dir / "run_default"
+            if run_default_dir.exists():
+                shutil.rmtree(run_default_dir)
+
             # Set up command for preprocessing
             preprocessing_command_list = [
                 "hydromt", "build", "wflow",
-                str(self.wflow_model_path / "wflow_test_full"),
+                str(wflow_test_full_dir),
                 "-r", region_information,
                 "-i", str(self.wflow_model_path / "wflow_build.yml"),
                 "-d", str(self.wflow_model_path / "data_catalog.yml"),

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
@@ -70,6 +70,8 @@ class PredefinedScenario(Process, ABC):
                           supported_formats=[Format("application/vnd.terriajs.catalog-member+json")]),
             ComplexOutput("floodDepth", "Maximum Flood Depth",
                           supported_formats=[Format("application/vnd.terriajs.catalog-member+json")]),
+            ComplexOutput("injectionPoints", "River Flows",
+                          supported_formats=[Format("application/vnd.terriajs.catalog-member+json")]),
             ComplexOutput("floodedBuildings", "Flooded Buildings",
                           supported_formats=[Format("application/vnd.terriajs.catalog-member+json")])
         ]
@@ -148,6 +150,9 @@ def handler_for_task(task: Task, is_baseline: bool = False) -> Callable:
         response.outputs['landcover'].data = json.dumps(landcover_catalog(scenario_id, scenario_name))
         response.outputs['catchmentBoundary'].data = json.dumps(catchment_boundary_catalog(scenario_id, scenario_name))
         response.outputs['floodDepth'].data = json.dumps(flood_depth_catalog(scenario_id, scenario_name))
+        response.outputs['injectionPoints'].data = json.dumps(
+            hydrograph_injection_point_catalog(scenario_id, scenario_name)
+        )
         response.outputs['floodedBuildings'].data = json.dumps(
             building_flood_status_catalog(scenario_id, scenario_name)
         )
@@ -411,4 +416,55 @@ def landcover_catalog(scenario_id: int, scenario_name: str) -> dict:
         "url": gs_landcover_url,
         "layers": layer_name,
         "styles": "landcover",
+    }
+
+
+def hydrograph_injection_point_catalog(scenario_id: int, scenario_name: str) -> dict:
+    """
+    Create a dictionary in the format of a terria js catalog json for the injection points, with hydrographs.
+
+    Parameters
+    ----------
+    scenario_id : int
+        The ID of the scenario to create the catalog item for.
+    scenario_name : str
+        The name of the scenario to create the catalog item for.
+
+    Returns
+    ----------
+    dict
+        The TerriaJS catalog item JSON for the building flood status layer.
+    """
+    gs_flood_inputs_workspace = f"{EnvVar.POSTGRES_DB}-flood-model-inputs"
+    gs_flood_inputs_url = f"{EnvVar.GEOSERVER_HOST}:{EnvVar.GEOSERVER_PORT}/geoserver/{gs_flood_inputs_workspace}/ows"
+
+    # Open and read HTML template for plot in infobox for TerriaJS
+    with open("./src/eddie_floodresilience/flood_model/templates/plot_infobox_template.html",
+              encoding="utf-8") as file:
+        plot_infobox_template = file.read()
+
+    # Fill in plot template vars. Some parts are double escaped so they can be used as moustache templates in TerriaJS.
+    plot_title = f"Hydrograph — Injection Point {{{{FID}}}} ({scenario_name})"
+    csv_src = f"{EnvVar.BACKEND_URL}/hydrographs/scenarios/{scenario_id}/features/{{{{FID}}}}"
+    plot_infobox_template = plot_infobox_template.format(
+        plot_title=plot_title,
+        csv_src=csv_src,
+        x_axis="Time",
+        y_axis="Flow",
+        y_units="Flow (m3/s)"
+    )
+
+    return {
+        "type": "wfs",
+        "name": f"Hydrographs - {scenario_name}",
+        "url": gs_flood_inputs_url,
+        "typeNames": f"{gs_flood_inputs_workspace}:injection_points",
+        "parameters": {
+            "CQL_FILTER": f"model_output_id={scenario_id}",
+        },
+        "featureInfoTemplate": {
+            # Double-escaped so that after python string formatting it is still mustache formatted.
+            "name": f"Hydrograph - {scenario_name} - {{{{FID}}}}",
+            "template": plot_infobox_template
+        }
     }

--- a/src/eddie_floodresilience/tasks.py
+++ b/src/eddie_floodresilience/tasks.py
@@ -28,6 +28,7 @@ from eddie.digitaltwin import cache_new_results, check_cache_results
 from eddie.digitaltwin.utils import setup_logging
 from eddie.tasks import OnFailureStateTask, app  # pylint: disable=cyclic-import
 from src.eddie_floodresilience import hydrological_and_hydrodynamic_pipeline
+from src.eddie_floodresilience.hydrological.wflow_serve_data_generator import get_hydrograph_csv
 
 setup_logging()
 log = logging.getLogger(__name__)
@@ -136,6 +137,26 @@ def create_hydrological_and_hydrodynamic_model_mataura_2020(location_geojson: st
     landcover_scenario_gdf = read_location_geojson(location_geojson, landcover_name)
     flood_model_output_id = hydrological_and_hydrodynamic_pipeline.mataura(landcover_scenario_gdf)
     return flood_model_output_id
+
+
+@app.task(base=OnFailureStateTask)
+def read_hydrograph_data(flood_model_id: int, injection_point_feature_id: str) -> str:
+    """
+    Task to run read hydrograph data for an injection point.
+
+    Parameters
+    ----------
+    flood_model_id: str
+        The flood model output ID to find query hydrograph data for.
+    injection_point_feature_id: str
+        The FID of the specific injection point to query hydrograph data for.
+
+    Returns
+    -------
+    str
+        CSV formatted hydrograph data for an injection point.
+    """
+    return get_hydrograph_csv(flood_model_id, injection_point_feature_id)
 
 
 def read_location_geojson(location_geojson: str | None, landcover_name: str | None) -> gpd.GeoDataFrame | None:


### PR DESCRIPTION
<img width="1817" height="886" alt="image" src="https://github.com/user-attachments/assets/29652254-f781-4a86-933d-e45f6ef48fb1" />

Adds hydrographs to the front-end

Closes #112 


General flow of a creating/viewing a hydrograph is as so:
1. `flood_model_siumulations_generator.py:serve_injection_points()`
Read the injection point files, format them into one-row-per-feature in the database, add the database table to geoserver.
2. `hydrological_and_hydrodynamic_service.py:hydrograph_injection_point_catalog()`
Add the injection points to the TerriaJS results shown. With plot template filled.
3. `wflow_serve_data_generator.py:get_hydrograph_csv()`
When a point is selected on the front end, read the database, and serve out the hydrograph as CSV
