### PR TITLE
Add difference rasters for scenarios comparing to baseline

### DIFF
--- a/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
@@ -24,16 +24,21 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
+import rasterio as rio
 from shapely.geometry import box
+from sqlalchemy.engine import Connection
+from sqlalchemy.sql import insert, text
 
 from eddie import geoserver
 from eddie.digitaltwin import setup_environment
+from eddie.digitaltwin.tables import create_table
 from eddie.digitaltwin.utils import LogLevel, setup_logging
 
 from src.eddie_floodresilience.config import EnvVariable
 from src.eddie_floodresilience.flood_model.bg_flood_model import store_model_output_metadata_to_db
 from src.eddie_floodresilience.flood_model.flooded_buildings import (
     find_flooded_buildings, store_flooded_buildings_in_database)
+from src.eddie_floodresilience.tables import FloodModelOutputDifference
 from . import serve_model
 from .flood_model_inputs_generator import InjectionPointsFloodModelGenerator, TerrainGenerator
 
@@ -203,7 +208,18 @@ class BaseFloodModelSimulationsGenerator(ABC):
         # Store metadata related to the BG Flood model output in the database
         engine = setup_environment.get_database()
         with engine.connect() as conn:
+            # Store model output metadata
             model_output_id = store_model_output_metadata_to_db(conn, output_tif, bbox_gdf)
+
+            # Save difference between scenario and baseline
+            baseline_id, baseline_path = find_baseline_flood_model(conn, bbox_gdf)
+            # Check if we are dealing with the first baseline run for this area
+            is_baseline = baseline_id == model_output_id
+            if not is_baseline:
+                # If not, then calculate and save the difference
+                difference_tif = write_difference(baseline_path, output_tif)
+                store_difference_metadata_to_db(conn, baseline_id, model_output_id, difference_tif)
+
             # Find buildings that are flooded to a depth greater than or equal to 0.1m
             log.info("Analysing flooded buildings")
             flooded_buildings = find_flooded_buildings(conn, bbox_gdf, output_tif,
@@ -215,10 +231,16 @@ class BaseFloodModelSimulationsGenerator(ABC):
         db_name = EnvVariable.POSTGRES_DB
         workspace_name = f"{db_name}-dt-model-outputs"
         geoserver.create_workspace_if_not_exists(workspace_name)
-        # Add the gtiff to geoserver
+
+        # Add the output gtiff to geoserver
         layer_name = f"output_{model_output_id}"
         geoserver.add_gtiff_to_geoserver(output_tif, workspace_name, layer_name)
         serve_model.create_viridis_style_if_not_exists()
+
+        if not is_baseline:
+            # Add the difference gtiff to geoserver
+            diff_layer_name = f"diff_{model_output_id}"
+            geoserver.add_gtiff_to_geoserver(difference_tif, workspace_name, diff_layer_name)
 
         return model_output_id
 
@@ -280,3 +302,114 @@ class BaseFloodModelSimulationsGenerator(ABC):
             narrow_df.to_postgis(table_name, conn, if_exists="append", index=False)
             # Serve the data
             geoserver.create_datastore_layer(conn, workspace_name, store_name, table_name)
+
+
+def find_baseline_flood_model(conn: Connection, area_of_interest: gpd.GeoDataFrame) -> tuple[int, Path]:
+    """
+    Retrieve the baseline model output an area of interest from the database.
+    This assumed that the lowest ID with the same AOI is the matching baseline.
+
+    Parameters
+    ----------
+    conn: Connection
+        The sqlalchemy database connection
+    area_of_interest : gpd.GeoDataFrame
+        A GeoDataFrame polygon specifying the area of interest to filter model outputs for
+
+    Returns
+    -------
+    tuple[int, Path]
+        Tuple containing the model output ID of the baseline and its model output path
+    """
+    # Get the area of interest polygon in well known text format for database querying
+    aoi_wkt = area_of_interest["geometry"][0].wkt
+    crs = area_of_interest.crs.to_epsg()
+    # Construct the query to find the baseline model output
+    query = text(
+        """
+        SELECT unique_id, file_path
+        FROM flood_model_output
+        WHERE ST_EQUALS(flood_model_output.geometry, ST_GeomFromText(:aoi_wkt, :crs))
+        ORDER BY unique_id
+        LIMIT 1;
+        """
+    ).bindparams(
+        aoi_wkt=str(aoi_wkt),
+        crs=str(crs)
+    )
+
+    # Execute the query and retrieve the result
+    row = conn.execute(query).fetchone()
+    return row.unique_id, row.file_path
+
+
+def write_difference(baseline_path: Path, scenario_path: Path) -> Path:
+    """
+    Calculate and write the difference raster comparing scenario to baseline.
+
+    Parameters
+    ----------
+    baseline_path : Path
+        Path to the baseline raster file.
+    scenario_path : Path
+        Path to the scenario raster file.
+
+    Returns
+    -------
+    Path
+        The path to the difference raster file.
+    """
+    # Set up path to difference file
+    scenario_timestamp = scenario_path.stem.split("-")[1]
+    difference_name = f"diff-{scenario_timestamp}.tif"
+    difference_path = scenario_path.parent / difference_name
+
+    # Open 2 source files
+    with (rio.open(baseline_path) as baseline_src, rio.open(scenario_path) as scenario_src):
+        # Open raster bands
+        baseline = baseline_src.read(1)
+        scenario = scenario_src.read(1)
+
+        # Calculate difference between rasters
+        difference = scenario - baseline
+
+        meta = baseline_src.meta.copy()
+        meta.update(dtype=difference.dtype)  # Ensure the correct datatype
+
+        # Write the output difference file
+        with rio.open(difference_path, "w", **meta) as dst:
+            dst.write(difference, 1)
+    return difference_path
+
+
+def store_difference_metadata_to_db(
+    conn: Connection,
+    baseline_id: int,
+    scenario_id: int,
+    difference_path: Path
+) -> None:
+    """
+    Store the data neccessary to find a difference raster in the database.
+
+    Parameters
+    ----------
+    conn : Connection
+        The connection used to connect to the database.
+    baseline_id : int
+        The baseline model output ID.
+    scenario_id : int
+        The scenario model output ID.
+    difference_path : Path
+        The path where the difference raster is stored.
+    """
+    # Ensure table exists
+    create_table(conn, FloodModelOutputDifference)
+    # Build the insert query
+    query = insert(FloodModelOutputDifference).values(
+        baseline_id=baseline_id,
+        scenario_id=scenario_id,
+        file_name=difference_path.name,
+        file_path=str(difference_path)
+    )
+    # Add the metadata to the database table.
+    conn.execute(query)

--- a/src/eddie_floodresilience/flood_model/templates/flood_depth_infobox.mustache
+++ b/src/eddie_floodresilience/flood_model/templates/flood_depth_infobox.mustache
@@ -1,4 +1,4 @@
-<!--Template used for TerriaJS to display information about a flooded building-->
+<!--Template used for TerriaJS to display information about flood depth-->
 <table class="cesium-infoBox-defaultTable">
   <tbody>
   <tr>

--- a/src/eddie_floodresilience/flood_model/templates/flood_depth_infobox.mustache
+++ b/src/eddie_floodresilience/flood_model/templates/flood_depth_infobox.mustache
@@ -4,7 +4,7 @@
   <tr>
     <td style="vertical-align: middle;"><b>Water Depth (m)</b></td>
     <!-- Double-escaped so that after python string formatting it is still mustache formatted. -->
-    <td>{{{{output_{flood_scenario_id}}}}}</td>
+    <td>{{{{{layer_name}}}}}</td>
   </tr>
   <tr>
     <td style="vertical-align: middle;"><b>Flood Scenario ID</b></td>

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
@@ -38,7 +38,8 @@ class PredefinedScenario(Process, ABC):
         """Define inputs and outputs of the WPS process, and assign process handler."""
         # Create bounding box WPS inputs
         if isBaseline:
-            # A very simple placeholder configuration for baseline
+            # A very simple placeholder configuration for baseline, ideally this would be removed.
+            # Inputs are required for TerriaJS though, so the front-end code would have to be fixed to allow this.
             inputs = [LiteralInput(
                 "options",
                 "Options",
@@ -301,9 +302,44 @@ def flood_depth_catalog(scenario_id: int, scenario_name: str) -> dict:
         The TerriaJS catalog item JSON for the flood depth layer.
     """
     gs_flood_model_workspace = f"{EnvVar.POSTGRES_DB}-dt-model-outputs"
-    gs_flood_url = f"{EnvVar.GEOSERVER_HOST}:{EnvVar.GEOSERVER_PORT}/geoserver/{gs_flood_model_workspace}/ows"
-    layer_name = f"{gs_flood_model_workspace}:output_{scenario_id}"
+    layer_name = f"output_{scenario_id}"
     style_name = "plasma_0_3m"
+    display_name = f"Flood Depth - {scenario_name}"
+    return _wms_depth_catalog(
+        scenario_id,
+        workspace_name=gs_flood_model_workspace,
+        fully_qualified_layer=layer_name,
+        display_name=display_name,
+        style_name=style_name
+    )
+
+
+def _wms_depth_catalog(
+    scenario_id: int, workspace_name: str, fully_qualified_layer: str, display_name: str, style_name: str
+) -> dict:
+    """
+    Helper function to build a WMS catalog item JSON based on the given parameters, for a raster about water depth.
+
+    Parameters
+    ----------
+    scenario_id : int
+        The ID of the scenario to create the catalog item for.
+    workspace_name : str
+        The name of the GeoServer workspace the layer lives in.
+    fully_qualified_layer : str
+        The name of the WMS layer within GeoServer.
+    display_name : str
+        The label to add to the catalog item in the front-end.
+    style_name : str
+        The name of the GeoServer style to display the layer with.
+
+    Returns
+    -------
+    dict
+        The TerriaJS catalog item JSON for the WMS Rster layer.
+    """
+    gs_service_url = f"{EnvVar.GEOSERVER_HOST}:{EnvVar.GEOSERVER_PORT}/geoserver/{workspace_name}/ows"
+    fully_qualified_layer = f"{workspace_name}:{fully_qualified_layer}"
     # Open and read HTML/mustache template file for infobox
     with open("./src/eddie_floodresilience/flood_model/templates/flood_depth_infobox.mustache",
               encoding="utf-8") as file:
@@ -315,7 +351,7 @@ def flood_depth_catalog(scenario_id: int, scenario_name: str) -> dict:
         "request": "GetLegendGraphic",
         "format": "image/png",
         "sld_version": "1.1.0",
-        "layer": layer_name,
+        "layer": fully_qualified_layer,
         "style": style_name,
         "transparent": "true",
         "LEGEND_OPTIONS": "hideEmptyRules:true;"
@@ -325,20 +361,20 @@ def flood_depth_catalog(scenario_id: int, scenario_name: str) -> dict:
                           "fontStyle:bold;"
                           "fontAntiAliasing:true;"
     }
-    legend_url = f"{gs_flood_url}?{urlencode(legend_url_params)}"
+    legend_url = f"{gs_service_url}?{urlencode(legend_url_params)}"
 
     return {
         "type": "wms",
-        "name": f"Flood Depth - {scenario_name}",
-        "url": gs_flood_url,
-        "layers": layer_name,
+        "name": display_name,
+        "url": gs_service_url,
+        "layers": fully_qualified_layer,
         "styles": style_name,
         "featureInfoTemplate": {
-            "name": f"Flood depth - {scenario_id}",
+            "name": display_name,
             "template": flood_depth_infobox_template.format(flood_scenario_id=scenario_id)
         },
         "legends": [{
-            "title": "Flood Depth",
+            "title": display_name,
             "url": legend_url,
             "urlMimeType": "image/png"
         }],

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
@@ -76,6 +76,12 @@ class PredefinedScenario(Process, ABC):
             ComplexOutput("floodedBuildings", "Flooded Buildings",
                           supported_formats=[Format("application/vnd.terriajs.catalog-member+json")])
         ]
+        # Add outputs that only make sense for non-baseline scenarios.
+        if not isBaseline:
+            outputs.append(
+                ComplexOutput("depthDifference", "Difference in Flood Depth to Baseline",
+                              supported_formats=[Format("application/vnd.terriajs.catalog-member+json")])
+            )
 
         handler = handler_for_task(task, isBaseline)
         # Initialise the process
@@ -157,6 +163,8 @@ def handler_for_task(task: Task, is_baseline: bool = False) -> Callable:
         response.outputs['floodedBuildings'].data = json.dumps(
             building_flood_status_catalog(scenario_id, scenario_name)
         )
+        if not is_baseline:
+            response.outputs['depthDifference'].data = json.dumps(depth_difference_catalog(scenario_id, scenario_name))
 
     return _handler
 
@@ -308,17 +316,42 @@ def flood_depth_catalog(scenario_id: int, scenario_name: str) -> dict:
     return _wms_depth_catalog(
         scenario_id,
         workspace_name=gs_flood_model_workspace,
-        fully_qualified_layer=layer_name,
+        layer_name=layer_name,
         display_name=display_name,
         style_name=style_name
     )
 
 
+def depth_difference_catalog(scenario_id: int, scenario_name: str) -> dict:
+    """
+    Create a dict in the format of a terria js catalog json for the difference between scenario and baseline depth.
+
+    Parameters
+    ----------
+    scenario_id : int
+        The ID of the scenario to create the catalog item for.
+    scenario_name : str
+        The name of the scenario to create the catalog item for.
+
+    Returns
+    ----------
+    dict
+        The TerriaJS catalog item JSON for the difference layer.
+    """
+    return _wms_depth_catalog(
+        scenario_id,
+        workspace_name=f"{EnvVar.POSTGRES_DB}-dt-model-outputs",
+        layer_name=f"diff_{scenario_id}",
+        display_name=f"Difference from baseline to {scenario_name}",
+        style_name="difference_r_b_0_2"
+    )
+
+
 def _wms_depth_catalog(
-    scenario_id: int, workspace_name: str, fully_qualified_layer: str, display_name: str, style_name: str
+    scenario_id: int, workspace_name: str, layer_name: str, display_name: str, style_name: str
 ) -> dict:
     """
-    Helper function to build a WMS catalog item JSON based on the given parameters, for a raster about water depth.
+    Build a WMS catalog item JSON based on the given parameters, for a raster about water depth.
 
     Parameters
     ----------
@@ -326,7 +359,7 @@ def _wms_depth_catalog(
         The ID of the scenario to create the catalog item for.
     workspace_name : str
         The name of the GeoServer workspace the layer lives in.
-    fully_qualified_layer : str
+    layer_name : str
         The name of the WMS layer within GeoServer.
     display_name : str
         The label to add to the catalog item in the front-end.
@@ -339,7 +372,7 @@ def _wms_depth_catalog(
         The TerriaJS catalog item JSON for the WMS Rster layer.
     """
     gs_service_url = f"{EnvVar.GEOSERVER_HOST}:{EnvVar.GEOSERVER_PORT}/geoserver/{workspace_name}/ows"
-    fully_qualified_layer = f"{workspace_name}:{fully_qualified_layer}"
+    fully_qualified_layer = f"{workspace_name}:{layer_name}"
     # Open and read HTML/mustache template file for infobox
     with open("./src/eddie_floodresilience/flood_model/templates/flood_depth_infobox.mustache",
               encoding="utf-8") as file:
@@ -371,7 +404,7 @@ def _wms_depth_catalog(
         "styles": style_name,
         "featureInfoTemplate": {
             "name": display_name,
-            "template": flood_depth_infobox_template.format(flood_scenario_id=scenario_id)
+            "template": flood_depth_infobox_template.format(flood_scenario_id=scenario_id, layer_name=layer_name),
         },
         "legends": [{
             "title": display_name,

--- a/src/eddie_floodresilience/tables.py
+++ b/src/eddie_floodresilience/tables.py
@@ -112,6 +112,31 @@ class FloodModelOutput(Base):
     geometry = Column(Geometry("POLYGON", srid=2193))
 
 
+class FloodModelOutputDifference(Base):
+    """
+    Class representing the 'flood_model_output_difference' table.
+
+    Attributes
+    ----------
+    __tablename__ : str
+        Name of the database table.
+    baseline_id : int
+        Foreign key for the matching baseline flood_model_output (primary key).
+    scenario_id : int
+        Foreign key for the matching scenario flood_model_output (primary key).
+    file_name : str
+        Name of the flood model output file.
+    file_path : str
+        Path to the flood model output file.
+    """  # pylint: disable=too-few-public-methods
+
+    __tablename__ = "flood_model_output_difference"
+    baseline_id = Column(Integer, primary_key=True)
+    scenario_id = Column(Integer, primary_key=True)
+    file_name = Column(String, comment="name of the flood model output file", nullable=True)
+    file_path = Column(String, comment="path to the flood model output file", nullable=True)
+
+
 class BuildingFloodStatus(Base):
     """
     Class representing the 'building_flood_status' table.

--- a/src/static/geo/difference_r_b_0_2.sld
+++ b/src/static/geo/difference_r_b_0_2.sld
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.0.0" xmlns:gml="http://www.opengis.net/gml"
+                       xmlns:ogc="http://www.opengis.net/ogc" xmlns:sld="http://www.opengis.net/sld">
+    <UserLayer>
+        <sld:LayerFeatureConstraints>
+            <sld:FeatureTypeConstraint/>
+        </sld:LayerFeatureConstraints>
+        <sld:UserStyle>
+            <sld:Name>difference_r_b_0_2</sld:Name>
+            <sld:FeatureTypeStyle>
+                <sld:Rule>
+                    <sld:RasterSymbolizer>
+                        <sld:ChannelSelection>
+                            <sld:GrayChannel>
+                                <sld:SourceChannelName>1</sld:SourceChannelName>
+                            </sld:GrayChannel>
+                        </sld:ChannelSelection>
+                        <sld:ColorMap type="ramp">
+                            <sld:ColorMapEntry color="#070033" label="-0.2m" quantity="-0.2"/>
+                            <sld:ColorMapEntry color="#0b11fb" label="-0.1m" quantity="-0.1"/>
+                            <sld:ColorMapEntry color="#ffffff" label="-0.03m" quantity="-0.03" opacity="1"/>
+                            <sld:ColorMapEntry color="#ffffff" quantity="-0.03" opacity="0"/>
+                            <sld:ColorMapEntry color="#ffffff" quantity="0.03" opacity="0"/>
+                            <sld:ColorMapEntry color="#ffffff" label="0.03m" quantity="0.03" opacity="1"/>
+                            <sld:ColorMapEntry color="#fb110b" label="0.1m" quantity="0.1"/>
+                            <sld:ColorMapEntry color="#350007" label="0.2m" quantity="0.2"/>
+                        </sld:ColorMap>
+                    </sld:RasterSymbolizer>
+                </sld:Rule>
+            </sld:FeatureTypeStyle>
+        </sld:UserStyle>
+    </UserLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
Closes #122 

<img width="1852" height="776" alt="image" src="https://github.com/user-attachments/assets/61c662d3-f836-4206-a89d-b8d39e36eb6c" />

Adds difference rasters to the interface. 

The baseline is assumed to be the row in the `flood_model_output` table with the same geometry and earliest ID. This should be sufficient.

If the legend is not styled nicely enough I suggest we make a new issue for this, to keep dev velocity high.




