### PR TITLE
Fix wflow_serve_data_generator missing new folders from PR #108

### DIFF
--- a/src/eddie_floodresilience/hydrological/wflow_data_catalog_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_data_catalog_generator.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 
 import yaml
+import geopandas as gpd
 
 from eddie.digitaltwin.utils import setup_logging, LogLevel
 
@@ -25,7 +26,7 @@ class DataCatalogGenerator:
         forcing_path: Path,
         river_name: str,
         scenario_and_id_folder: Path,
-        polygons: str = None,
+        polygons: gpd.GeoDataFrame | None = None,
         landcover: str = 'globcover'
     ) -> None:
         """
@@ -43,8 +44,8 @@ class DataCatalogGenerator:
             Name of directory to where the river information files are stored
         scenario_and_id_folder: Path
             Directory to the scenario folder name with ID
-        polygons : str = None
-            Name of polygon file that is used to change the landcover information.
+        polygons : gpd.GeoDataFrame | None = None
+            Polygons that are used to change the landcover information.
             This polygon dataframe has 'landcover' column with new values
         landcover : str = 'globcover'
             Name of land cover. Default is 'globcover'

--- a/src/eddie_floodresilience/hydrological/wflow_data_catalog_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_data_catalog_generator.py
@@ -57,6 +57,27 @@ class DataCatalogGenerator:
         self.polygons = polygons
         self.landcover = landcover
 
+    @staticmethod
+    def landcover_mapping_type(landcover: str) -> str:
+        """
+        Identify what type of landcover data source is being used.
+
+        Parameters
+        ----------
+        landcover : str
+            Name of land cover.
+
+        Returns
+        ----------
+        str
+            Name of landcover dataset - globcover or lcdb
+        """
+        if landcover.startswith('globcover'):
+            landcover_mapping_type = 'globcover'
+        else:
+            landcover_mapping_type = 'lcdb'
+        return landcover_mapping_type
+
     def meta_section(self) -> dict:
         """
         Write out meta section
@@ -159,10 +180,7 @@ class DataCatalogGenerator:
         landcover : dict
             A dictionary contains information of landcover
         """
-        if self.landcover.startswith('globcover'):
-            landcover_mapping_type = 'globcover'
-        else:
-            landcover_mapping_type = 'lcdb'
+        landcover_mapping_type = self.landcover_mapping_type(self.landcover)
 
         # Check landcover path
         is_baseline = self.polygons is None

--- a/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
@@ -45,15 +45,25 @@ class WflowServeDataGenerator:
     ----------
     hydromt_path : Path
         A directory to where all necessary files are stored to run wflow model
-    wflow_model_path : Path
-        A directory to where the data_catalog.yml is stored for WFlow
-    landcover : str
-        A string to identify the landcover. Meets the approximate regex "(globcover(_\d\d\d.tif)?)|(lcdb(_\d\d\d.tif))"
+    polygons: gpd.GeoDataFrame | None
+        Polygons that are used to change the landcover information.
+        This polygon dataframe has 'landcover' column with new values
+    landcover_mapping_type : str
+        Name of landcover dataset - globcover or lcdb
+    scenario_and_id_folder : Path
+        Directory to the scenario folder name with ID
     flood_model_output_id : int
         The ID of the flood model scenario that has been created using this wflow model
     """  # pylint: disable=too-few-public-methods
 
-    def __init__(self, hydromt_path: Path, wflow_model_path: Path, landcover: str, flood_model_output_id: int) -> None:
+    def __init__(
+        self,
+        hydromt_path: Path,
+        polygons: gpd.GeoDataFrame | None,
+        landcover_mapping_type: str,
+        scenario_and_id_folder: Path,
+        flood_model_output_id: int
+    ) -> None:
         r"""
         Define paths and variables relating to serving a Wflow scenario.
 
@@ -61,17 +71,20 @@ class WflowServeDataGenerator:
         ----------
         hydromt_path : Path
             A directory to where all necessary files are stored to run wflow model
-        wflow_model_path : Path
-            A directory to where the data_catalog.yml is stored for WFlow
-        landcover : str
-            A string to identify the landcover.
-            Meets the approximate regex "(globcover(_\d\d\d.tif)?)|(lcdb(_\d\d\d.tif))"
+        polygons: gpd.GeoDataFrame | None
+            Polygons that are used to change the landcover information.
+            This polygon dataframe has 'landcover' column with new values
+        landcover_mapping_type : str
+            Name of landcover dataset - globcover or lcdb
+        scenario_and_id_folder : Path
+            Directory to the scenario folder name with ID
         flood_model_output_id : int
             The ID of the flood model scenario that has been created using this wflow model
         """
         self.hydromt_path = hydromt_path
-        self.wflow_model_path = wflow_model_path
-        self.landcover = landcover
+        self.polygons = polygons
+        self.landcover_mapping_type = landcover_mapping_type
+        self.scenario_and_id_folder = scenario_and_id_folder
         self.flood_model_output_id = flood_model_output_id
 
     def serve_data(self) -> None:
@@ -91,7 +104,7 @@ class WflowServeDataGenerator:
         workspace_name = f"{db_name}-intermediate-wflow"
 
         # Read catchment polygon
-        catchment_file = self.wflow_model_path / "wflow_test_full/staticgeoms/basins.geojson"
+        catchment_file = self.scenario_and_id_folder / "hydrological_process/wflow_test_full/staticgeoms/basins.geojson"
         catchment_poly = gpd.read_file(catchment_file)
         if catchment_poly.crs.to_epsg() is None:
             raise KeyError(f"CRS is not defined in EPSG# form in vector file {catchment_file}.")
@@ -114,8 +127,10 @@ class WflowServeDataGenerator:
         catchment_poly : gpd.GeoDataFrame
             The catchment polygon to clip the landcover raster to before serving to reduce space.
         """
-        is_baseline = self.landcover == "globcover"
-        landcover_file = find_landcover_file(self.wflow_model_path, self.hydromt_path, self.landcover, is_baseline)
+        is_baseline = self.polygons is None
+        landcover_file = find_landcover_file(
+            self.hydromt_path, self.landcover_mapping_type, self.scenario_and_id_folder, is_baseline
+        )
 
         tmp_dir = Path("tmp/gtiff") / self.hydromt_path.name
         tmp_dir.mkdir(parents=True, exist_ok=True)

--- a/src/eddie_floodresilience/hydrological/wflow_simulations_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_simulations_generator.py
@@ -60,8 +60,8 @@ class WflowSimulationsGenerator:
         Number of threads that controls how fast the wflow model can run
     scenario_and_id_folder : Path
         Directory to the scenario folder name with ID
-    polygons : str = None
-        Name of polygon file that is used to change the landcover information.
+    polygons : gpd.GeoDataFrame | None = None
+        Polygons that are used to change the landcover information.
         This polygon dataframe has 'landcover' column with new values
     resolution : float
         Resolution for flow data.
@@ -80,7 +80,7 @@ class WflowSimulationsGenerator:
         flood_aoi_boundary: list,
         num_threads: int,
         scenario_and_id_folder: Path,
-        polygons: str = None,
+        polygons: gpd.GeoDataFrame | None = None,
         resolution: float = 0.00045,
         landcover: str = 'globcover'
     ) -> None:
@@ -110,8 +110,8 @@ class WflowSimulationsGenerator:
             Number of threads that controls how fast the wflow model can run
         scenario_and_id_folder : Path
             Directory to the new scenario ID for scenario
-        polygons : str = None
-            Name of polygon file that is used to change the landcover information.
+        polygons : gpd.GeoDataFrame | None = None
+            Polygons that are used to change the landcover information.
             This polygon dataframe has 'landcover' column with new values
         resolution : float
             Resolution for flow data.

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
@@ -20,6 +20,7 @@ from eddie.digitaltwin import retrieve_from_instructions
 from eddie.digitaltwin.setup_environment import get_database
 from eddie.digitaltwin.tables import create_table
 from eddie.digitaltwin.utils import setup_logging, LogLevel
+from eddie_floodresilience.hydrological.wflow_data_catalog_generator import DataCatalogGenerator
 
 from src.eddie_floodresilience.config import EnvVariable
 from src.eddie_floodresilience.hydrological.wflow_serve_data_generator import WflowServeDataGenerator
@@ -377,7 +378,7 @@ class HydrologicalAndHydrodynamicPipeline:
         flood_model_output_id: int
             The flood model output ID to associate the WFlow data with
         """
-        landcover_mapping_type = "globcover" if self.landcover.startswith("globcover") else "lcdb"
+        landcover_mapping_type = DataCatalogGenerator.landcover_mapping_type(self.landcover)
         wflow_serve_data = WflowServeDataGenerator(
             self.hydromt_path,
             self.polygons,

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
@@ -20,9 +20,9 @@ from eddie.digitaltwin import retrieve_from_instructions
 from eddie.digitaltwin.setup_environment import get_database
 from eddie.digitaltwin.tables import create_table
 from eddie.digitaltwin.utils import setup_logging, LogLevel
-from eddie_floodresilience.hydrological.wflow_data_catalog_generator import DataCatalogGenerator
 
 from src.eddie_floodresilience.config import EnvVariable
+from src.eddie_floodresilience.hydrological.wflow_data_catalog_generator import DataCatalogGenerator
 from src.eddie_floodresilience.hydrological.wflow_serve_data_generator import WflowServeDataGenerator
 from src.eddie_floodresilience.solutions.total_solutions import LandCoverSolution, ElevationSolution
 from src.eddie_floodresilience.preprocessing.terrain_data_for_wflow_generator import TerrainDataWflowGenerator
@@ -821,14 +821,14 @@ def riverton(
 
 if __name__ == '__main__':
     # Whirinaki
-    gdf = gpd.read_file(
-        r"D:\Digital_Twin_data\hydrological_hydrodynamic_path_031\whirinaki\polygons\polygons.shp"
-    )
-    df = pd.read_csv(
-        r"D:\Digital_Twin_data\hydrological_hydrodynamic_path_031\whirinaki\vectors\vectors.csv"
-    )
-    whirinaki(gdf, df)
-
+    # gdf = gpd.read_file(
+    #     r"D:\Digital_Twin_data\hydrological_hydrodynamic_path_031\whirinaki\polygons\polygons.shp"
+    # )
+    # df = pd.read_csv(
+    #     r"D:\Digital_Twin_data\hydrological_hydrodynamic_path_031\whirinaki\vectors\vectors.csv"
+    # )
+    # whirinaki(gdf, df)
+    whirinaki()
     # # Riverton
     # riverton(None, None)
 

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
@@ -366,19 +366,23 @@ class HydrologicalAndHydrodynamicPipeline:
         # Generate wflow model data
         wflow_data.wflow_model_simulations_pipeline()
 
-    def serve_wflow_data(self, flood_model_output_id: int) -> None:
+    def serve_wflow_data(self, scenario_and_id_folder: Path, flood_model_output_id: int) -> None:
         """
         Serve data for a Wflow scenario, such as landcover and catchment boundaries.
 
         Parameters
         ----------
+        scenario_and_id_folder: Path
+            Directory to the scenario folder name with ID
         flood_model_output_id: int
             The flood model output ID to associate the WFlow data with
         """
+        landcover_mapping_type = "globcover" if self.landcover.startswith("globcover") else "lcdb"
         wflow_serve_data = WflowServeDataGenerator(
             self.hydromt_path,
-            self.hydro_combination_path,
-            self.landcover,
+            self.polygons,
+            landcover_mapping_type,
+            scenario_and_id_folder,
             flood_model_output_id
         )
 
@@ -490,7 +494,7 @@ class HydrologicalAndHydrodynamicPipeline:
             # Generate flood data
             flood_model_output_id = self.flood_data_pipeline(scenario_and_id_folder)
 
-        self.serve_wflow_data(flood_model_output_id)
+        self.serve_wflow_data(scenario_and_id_folder, flood_model_output_id)
         return flood_model_output_id
 
 


### PR DESCRIPTION
In `wflow_serve_data_generator`, the new storage directories from #108 weren't set up.

This PR fixes that, and since it adds `self.polygons` to the class, it also ensures the type is correct in documentation upstream.

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [x] Test locally and ensure tests are passing
- [x] Update documentation
  - [ ] Readme
  - [x] Docstrings
  - [x] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
