### PR TITLE
Restore docker celery worker

### DIFF
--- a/.env.docker-override
+++ b/.env.docker-override
@@ -5,8 +5,7 @@ DATA_DIR_MODEL_OUTPUT=/stored_data/model_output
 DATA_DIR_GEOSERVER=/stored_data/geoserver
 FLOOD_MODEL_DIR=/bg_flood
 
-#todo this would be better if it wasn't so coupled
-HYDRO_COMBINATION_PATH="/stored_data/mataura/hydrological_hydrodynamic_mataura_path_001"
+HYDRO_COMBINATION_PATH="/stored_data/hydrological_hydrodynamic"
 HYDROMT_PATH="/necessary_data"
 PRECIPITATION_PATH="/Barra"
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following list defines the basic steps required to set up and run the digita
 
 ### Officially Supported Operating Systems
 
-* Windows 10/11
+* Windows 10/11 Note: Performance may not be as good on WSL as on Linux.
 * Ubuntu 22.04
 
 Note: Other Linux-based operating systems are likely to work but have not been as thoroughly tested.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -32,7 +32,7 @@ services:
     # Bind host data directories to container, allowing different instances to share data sources.
     - ${DATA_DIR}:/stored_data
     - ${DATA_DIR_GEOSERVER}:/stored_data/geoserver
-    - ${HYDROMT_PATH}:/necessary_data
+    - ${HYDROMT_PATH}:/necessary_data:ro
 
   terria_map:
     volumes:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,11 +17,29 @@
 # Definitions of services using local data_directory bind mounts for development use only.
 # Merges with the primary `docker-compose.yml`
 # Use with `docker compose -f docker-compose.yml docker-compose-dev.yml`
+volumes:
+  # Separate the database volume from the base services because this one will contain local file paths
+  fredt_postgres_db_vol_dev:
 
 services:
+  db_postgres:
+    volumes:
+    - fredt_postgres_db_vol_dev:/var/lib/postgresql/data
+
+  celery_worker:
+    restart: no
+    volumes:
+    # Bind host data directories to container, allowing different instances to share data sources.
+    - ${DATA_DIR}:/stored_data
+    - ${DATA_DIR_GEOSERVER}:/stored_data/geoserver
+    - ${HYDROMT_PATH}:/necessary_data
 
   terria_map:
     volumes:
     # Allows development config to be updated on refresh, instead of rebuild
     - ./terriajs/client_config.json:/app/wwwroot/config.json
     - ./terriajs/catalog.json:/app/wwwroot/init/catalog.json
+
+  geoserver:
+    volumes:
+    - ${DATA_DIR_GEOSERVER}:/opt/geoserver_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,6 @@ services:
       - .env
       - api_keys.env
       - .env.docker-override
-    volumes:
-      - stored_data:/stored_data
     healthcheck:
       test: curl --fail -s http://localhost:5000/ || exit 1
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       # Bind host data directories to container, allowing different instances to share data sources.
       - stored_data:/stored_data
       - geoserver_data:/stored_data/geoserver
-      - ${HYDROMT_PATH}:/necessary_data
+      - ${HYDROMT_PATH}:/necessary_data:ro
     ports:
       - "5001:5001"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,41 @@ services:
       - message_broker
       - geoserver
 
+  celery_worker:
+    # Performs tasks such as complex computation asynchronously on behalf of backend
+    build:
+      context: .
+      dockerfile: docker/eddie.Dockerfile
+    container_name: celery_worker_digital_twin
+    entrypoint: ["src/celery_worker_entrypoint.sh"]
+    restart: always
+    env_file:
+      - .env
+      - api_keys.env
+      - .env.docker-override
+    volumes:
+      # Bind host data directories to container, allowing different instances to share data sources.
+      - stored_data:/stored_data
+      - geoserver_data:/stored_data/geoserver
+      - ${HYDROMT_PATH}:/necessary_data
+    ports:
+      - "5001:5001"
+    healthcheck:
+      test: curl --fail -s http://localhost:5001/ || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    depends_on:
+      - db_postgres
+      - message_broker
+      - geoserver
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            count: all # Use all available GPUs
+            capabilities: [ gpu ]
 
   geoserver:
     # Serves geospatial web data through interactions with files and database
@@ -71,7 +106,7 @@ services:
       dockerfile: geoserver.Dockerfile
     container_name: geoserver_digital_twin
     volumes:
-      - ${DATA_DIR_GEOSERVER}:/opt/geoserver_data
+      - geoserver_data:/opt/geoserver_data
     depends_on:
       - db_postgres
     environment:

--- a/docker/eddie.Dockerfile
+++ b/docker/eddie.Dockerfile
@@ -104,10 +104,6 @@ ENV JULIA_DEPOT_PATH="/opt/julia"
 # Install Julia package Wflow
 RUN julia -e 'using Pkg; Pkg.update(); Pkg.add(name="Wflow", version="0.8.1")'
 
-COPY --chown=nonroot:nonroot --chmod=755 stored_data_mataura_template/rainfall_gauges_HIRDS /Barra
-COPY --chown=nonroot:nonroot --chmod=755 stored_data_mataura_template/hydrological_hydrodynamic_mataura_path_001 /stored_data/mataura/hydrological_hydrodynamic_mataura_path_001
-COPY --chown=nonroot:nonroot --chmod=755 stored_data_mataura_template/necessary_data /necessary_data
-
 # Copy python virtual environment from build layer
 COPY --chown=root:root --chmod=777 --from=build /venv /venv
 USER nonroot

--- a/docker/eddie.Dockerfile
+++ b/docker/eddie.Dockerfile
@@ -105,16 +105,14 @@ ENV JULIA_DEPOT_PATH="/opt/julia"
 RUN julia -e 'using Pkg; Pkg.update(); Pkg.add(name="Wflow", version="0.8.1")'
 
 # Copy python virtual environment from build layer
-COPY --chown=root:root --chmod=777 --from=build /venv /venv
-USER nonroot
+COPY --chown=root:root --chmod=655 --from=build /venv /venv
+
 # download whitebox binaries
 RUN <<EOF
   set -ex
   source /venv/bin/activate
   python -c "from whitebox.whitebox_tools import WhiteboxTools; wbt = WhiteboxTools()"
 EOF
-
-USER root
 
 # Copy source files and essential runtime files
 COPY --chown=root:root --chmod=444 selected_polygon.geojson .

--- a/terriajs/catalog.json
+++ b/terriajs/catalog.json
@@ -13,6 +13,20 @@
       "members": [
         {
           "type": "wps",
+          "name": "Whirinaki 1999 Baseline",
+          "description": "Model a land cover change scenario that will impact the flood scenario",
+          "url": "$BACKEND_URL/wps",
+          "identifier": "whirinaki1999baseline"
+        },
+        {
+          "type": "wps",
+          "name": "Whirinaki 1999 Land Cover Change",
+          "description": "Model a land cover change scenario that will impact the flood scenario",
+          "url": "$BACKEND_URL/wps",
+          "identifier": "whirinaki1999"
+        },
+        {
+          "type": "wps",
           "name": "Mataura 2020 Baseline",
           "description": "Model a land cover change scenario that will impact the flood scenario",
           "url": "$BACKEND_URL/wps",


### PR DESCRIPTION
Preparations to run this on a VM server, e.g. Digital Ocean (Code tasks for #94)

- Removes 777 permission on venv, reducing attack vector footprint (Closes #84)
- Reduces image sizes by making neccessary_data  a bind-mount only directory. (Closes #88)
  - Pros: reduces image sizes
  - Cons: May cause issues with SE Linux, but it is read-only so this should be ok.
- Removes references to mataura in docker paths (Closes #89) 
- Restores docker-compose-dev.yml (Closes #90) - although performance is not great, this still improves choice for Developer Experience
- Restores full docker capability. (Closes #91).
- (Closes #59)
- Makes necessary data read only on linux, to reduce security attack vector footprint (Closes #161)
- Restores the Northland catalog items


## TODO:
- [x] Make necessary data read only
- [x] Add readme
- [x] remove stored data from backend service
- [ ] Run final development test after the above todo changes

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [x] Ensure these tests have the expected behaviour
  - [x] Test locally and ensure tests are passing
- [x] Update documentation
  - [x] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [x] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
