### PR TITLE
125 log each task with celery id during processing

### DIFF
--- a/src/eddie_floodresilience/flood_model/bgflood/bgflood_parameters_generator.py
+++ b/src/eddie_floodresilience/flood_model/bgflood/bgflood_parameters_generator.py
@@ -25,10 +25,8 @@ import geopandas as gpd
 import numpy as np
 from shapely.geometry import Polygon, Point
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
 from ..flood_model_parameters_generator import FloodType, FloodModelParametersGenerator
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/flood_model/bgflood/bgflood_precipitation.py
+++ b/src/eddie_floodresilience/flood_model/bgflood/bgflood_precipitation.py
@@ -21,10 +21,8 @@ import logging
 
 import xarray as xr
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
 from ..flood_model_precipitation import BasePrecipitationFloodModelGenerator, PrecipitationGenerator
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/flood_model/bgflood/bgflood_simulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/bgflood/bgflood_simulations_generator.py
@@ -24,8 +24,6 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from eddie.digitaltwin.utils import LogLevel, setup_logging
-
 from src.eddie_floodresilience.config import EnvVariable
 from src.eddie_floodresilience.flood_model.serve_model import convert_nc_to_gtiff
 from .bgflood_parameters_generator import BGFloodParametersGenerator
@@ -33,7 +31,6 @@ from .bgflood_precipitation import BGFloodPrecipitationGenerator, BGFloodPrecipi
 from ..flood_model_parameters_generator import FloodType
 from ..flood_model_siumulations_generator import BaseFloodModelSimulationsGenerator
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/flood_model/flood_model_inputs_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_inputs_generator.py
@@ -27,10 +27,6 @@ import pandas as pd
 import xarray as xr
 from shapely.geometry import box, mapping, Point, Polygon, LineString, MultiLineString, MultiPoint
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
-
-
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/flood_model/flood_model_parameters_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_parameters_generator.py
@@ -17,7 +17,6 @@
 
 """This script sets parameter files for flood model runs."""
 
-import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import StrEnum
@@ -26,12 +25,7 @@ from pathlib import Path
 import pandas as pd
 from shapely.geometry import Polygon
 
-from eddie.digitaltwin.utils import LogLevel, setup_logging
-
 from src.eddie_floodresilience.flood_model.flood_model_tide_generator import TidalDataGenerator
-
-setup_logging(LogLevel.DEBUG)
-log = logging.getLogger(__name__)
 
 
 class FloodType(StrEnum):

--- a/src/eddie_floodresilience/flood_model/flood_model_precipitation.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_precipitation.py
@@ -27,9 +27,6 @@ import xarray as xr
 from tqdm import tqdm
 from rasterio.enums import Resampling
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
-
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
@@ -32,7 +32,6 @@ from sqlalchemy.sql import insert, text
 from eddie import geoserver
 from eddie.digitaltwin import setup_environment
 from eddie.digitaltwin.tables import create_table
-from eddie.digitaltwin.utils import LogLevel, setup_logging
 
 from src.eddie_floodresilience.config import EnvVariable
 from src.eddie_floodresilience.flood_model.bg_flood_model import store_model_output_metadata_to_db
@@ -43,7 +42,6 @@ from . import serve_model
 from .flood_model_inputs_generator import InjectionPointsFloodModelGenerator, TerrainGenerator
 from .flood_model_parameters_generator import FloodType
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/flood_model/flood_model_tide_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_tide_generator.py
@@ -27,10 +27,8 @@ import pandas as pd
 import requests
 from shapely.geometry import Point, Polygon
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
 from src.eddie_floodresilience import config
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/flood_model/lisflood/lisflood_parameters_generator.py
+++ b/src/eddie_floodresilience/flood_model/lisflood/lisflood_parameters_generator.py
@@ -24,10 +24,8 @@ import geopandas as gpd
 import pandas as pd
 import numpy as np
 
-from eddie.digitaltwin.utils import LogLevel, setup_logging
 from ..flood_model_parameters_generator import FloodModelParametersGenerator, FloodType
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/flood_model/lisflood/lisflood_precipitation.py
+++ b/src/eddie_floodresilience/flood_model/lisflood/lisflood_precipitation.py
@@ -17,13 +17,7 @@
 
 """This script formats and writes precipitation data for LISFLOOD-FP inputs."""
 
-import logging
-
-from eddie.digitaltwin.utils import setup_logging, LogLevel
 from ..flood_model_precipitation import BasePrecipitationFloodModelGenerator
-
-setup_logging(LogLevel.DEBUG)
-log = logging.getLogger(__name__)
 
 
 class LisfloodPrecipitationFloodModelGenerator(BasePrecipitationFloodModelGenerator):

--- a/src/eddie_floodresilience/flood_model/lisflood/lisflood_simulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/lisflood/lisflood_simulations_generator.py
@@ -24,8 +24,6 @@ import platform
 import shutil
 import subprocess
 
-from eddie.digitaltwin.utils import LogLevel, setup_logging
-
 from src.eddie_floodresilience.config import EnvVariable
 from src.eddie_floodresilience.flood_model import serve_model
 from .lisflood_inputs_generator import TerrainFloodModelGenerator
@@ -35,7 +33,6 @@ from ..flood_model_parameters_generator import FloodType
 from ..flood_model_precipitation import PrecipitationGenerator
 from ..flood_model_siumulations_generator import BaseFloodModelSimulationsGenerator
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/hydrological/wflow_build_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_build_generator.py
@@ -13,9 +13,6 @@ from dateutil.relativedelta import relativedelta
 
 import yaml
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
-
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/hydrological/wflow_data_catalog_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_data_catalog_generator.py
@@ -11,9 +11,6 @@ from pathlib import Path
 import yaml
 import geopandas as gpd
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
-
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
@@ -28,12 +28,10 @@ import rioxarray as rxr
 
 from eddie import geoserver as gs
 from eddie.digitaltwin import setup_environment
-from eddie.digitaltwin.utils import setup_logging
 from eddie.geoserver.raster_layers import CoverageDimension
 from src.eddie_floodresilience.config import EnvVariable
 from src.eddie_floodresilience.hydrological.wflow_data_catalog_generator import find_landcover_file
 
-setup_logging()
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/hydrological/wflow_simulations_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_simulations_generator.py
@@ -25,11 +25,9 @@ from datetime import datetime
 
 import geopandas as gpd
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
 from .wflow_data_catalog_generator import DataCatalogGenerator
 from .wflow_build_generator import WflowBuildGenerator
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
@@ -33,7 +33,6 @@ from src.eddie_floodresilience.flood_model.lisflood.lisflood_simulations_generat
     LisFloodModelSimulationsGenerator
 from src.eddie_floodresilience.tables import PipelineOutput
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 
@@ -851,6 +850,7 @@ def riverton(
 
 
 if __name__ == '__main__':
+    setup_logging(LogLevel.DEBUG)
     # Whirinaki
     gdf = gpd.read_file(
         r"D:\Digital_Twin_data\hydrological_hydrodynamic_path_031\whirinaki\polygons\polygons.shp"

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
@@ -468,7 +468,11 @@ class HydrologicalAndHydrodynamicPipeline:
 
         # Download external spatial data into database
         bbox_gdf = gpd.GeoDataFrame(geometry=[box(*self.flood_aoi_boundary)], crs="EPSG:2193")
-        retrieve_from_instructions.main(bbox_gdf, Path("src/eddie_floodresilience/static_boundary_instructions.json"))
+        retrieve_from_instructions.main(
+            bbox_gdf,
+            Path("src/eddie_floodresilience/static_boundary_instructions.json"),
+            log_level=LogLevel.INFO
+        )
 
         # Set scenario
         scenario_and_id_folder = self.scenario_folder_generator()
@@ -850,7 +854,7 @@ def riverton(
 
 
 if __name__ == '__main__':
-    setup_logging(LogLevel.DEBUG)
+    setup_logging(LogLevel.INFO)
     # Whirinaki
     gdf = gpd.read_file(
         r"D:\Digital_Twin_data\hydrological_hydrodynamic_path_031\whirinaki\polygons\polygons.shp"

--- a/src/eddie_floodresilience/preprocessing/terrain_attributes_generator.py
+++ b/src/eddie_floodresilience/preprocessing/terrain_attributes_generator.py
@@ -19,9 +19,6 @@ from shapely.geometry import box, LineString, MultiLineString
 from whitebox.whitebox_tools import WhiteboxTools
 from whitebox_workflows import WbEnvironment, Raster
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
-
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 # Create whitebox environment and whitebox tools

--- a/src/eddie_floodresilience/preprocessing/terrain_data_for_wflow_generator.py
+++ b/src/eddie_floodresilience/preprocessing/terrain_data_for_wflow_generator.py
@@ -8,12 +8,10 @@ Created on Sat Apr 11 16:23:13 2026
 import logging
 from pathlib import Path
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
 from .terrain_data_manipulator import TerrainFilter
 from .terrain_attributes_generator import StreamTopologyGenerator, StreamHydraulicsGenerator
 from .terrain_data_for_wflow_preparator import TerrainDataWflowPreparator
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/preprocessing/terrain_data_for_wflow_preparator.py
+++ b/src/eddie_floodresilience/preprocessing/terrain_data_for_wflow_preparator.py
@@ -1,6 +1,5 @@
 """Generate data for wflow from terrain attributes generated before"""
 
-import logging
 import os
 from pathlib import Path
 from typing import Tuple
@@ -12,11 +11,6 @@ import pyflwdir
 import rioxarray as rxr
 import xarray as xr
 from hydromt import flw
-
-from eddie.digitaltwin.utils import setup_logging, LogLevel
-
-setup_logging(LogLevel.DEBUG)
-log = logging.getLogger(__name__)
 
 
 class TerrainDataWflowPreparator:

--- a/src/eddie_floodresilience/preprocessing/terrain_data_manipulator.py
+++ b/src/eddie_floodresilience/preprocessing/terrain_data_manipulator.py
@@ -21,9 +21,6 @@ from pathlib import Path
 
 import rioxarray as rxr
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
-
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 

--- a/src/eddie_floodresilience/solutions/total_solutions.py
+++ b/src/eddie_floodresilience/solutions/total_solutions.py
@@ -29,9 +29,7 @@ from scipy.ndimage import distance_transform_edt
 from whitebox.whitebox_tools import WhiteboxTools
 from whitebox_workflows import WbEnvironment
 
-from eddie.digitaltwin.utils import setup_logging, LogLevel
 
-setup_logging(LogLevel.DEBUG)
 log = logging.getLogger(__name__)
 
 GLOBCOVER_CLASSES: dict[str, int] = {

--- a/src/eddie_floodresilience/tasks.py
+++ b/src/eddie_floodresilience/tasks.py
@@ -19,19 +19,16 @@
 Runs backend tasks using Celery. Allowing for multiple long-running tasks to complete in the background.
 Allows the frontend to send tasks and retrieve status later.
 """
-import logging
 from typing import List, NamedTuple
 
 import geopandas as gpd
+from celery.signals import setup_logging as celery_setup_logging_signal
 
 from eddie.digitaltwin import cache_new_results, check_cache_results
-from eddie.digitaltwin.utils import setup_logging
+from eddie.digitaltwin.utils import setup_logging, LogLevel
 from eddie.tasks import OnFailureStateTask, app  # pylint: disable=cyclic-import
 from src.eddie_floodresilience import hydrological_and_hydrodynamic_pipeline
 from src.eddie_floodresilience.hydrological.wflow_serve_data_generator import get_hydrograph_csv
-
-setup_logging()
-log = logging.getLogger(__name__)
 
 
 class DepthTimePlot(NamedTuple):
@@ -50,6 +47,12 @@ class DepthTimePlot(NamedTuple):
 
     depths: List[float]
     times: List[float]
+
+
+@celery_setup_logging_signal.connect
+def configure_celery_logging(*_args: tuple, **_kwargs: dict) -> None:  # pylint: disable=missing-param-doc
+    """Set up celery logging to use the same logging as if running the modules directly."""
+    setup_logging(LogLevel.INFO)
 
 
 @app.task(base=OnFailureStateTask)

--- a/src/eddie_floodresilience/tasks.py
+++ b/src/eddie_floodresilience/tasks.py
@@ -116,7 +116,9 @@ def create_hydrological_and_hydrodynamic_model_whirinaki_1999(
         The resultant flood model output ID.
     """
     landcover_scenario_gdf = read_location_geojson(location_geojson, landcover_name)
-    flood_model_output_id = hydrological_and_hydrodynamic_pipeline.whirinaki(landcover_scenario_gdf)
+    flood_model_output_id = hydrological_and_hydrodynamic_pipeline.whirinaki(
+        landcover_scenario_gdf=landcover_scenario_gdf
+    )
     return flood_model_output_id
 
 
@@ -138,7 +140,9 @@ def create_hydrological_and_hydrodynamic_model_mataura_2020(location_geojson: st
         The resultant flood model output ID.
     """
     landcover_scenario_gdf = read_location_geojson(location_geojson, landcover_name)
-    flood_model_output_id = hydrological_and_hydrodynamic_pipeline.mataura(landcover_scenario_gdf)
+    flood_model_output_id = hydrological_and_hydrodynamic_pipeline.mataura(
+        landcover_scenario_gdf=landcover_scenario_gdf
+    )
     return flood_model_output_id
 
 


### PR DESCRIPTION
Closes #125

This is required so that we can read logs when multiple people are running the system. (for #160)

Some of these changes are in the EDDIE library repo (https://github.com/GeospatialResearch/Digital-Twins/commit/a8e50b803a18ae204cbf37785ceae0c021c8c6f5)

##
Changes:
- Celery now runs the same logging system as regular python
- Added celery task ID column to logging if celery is running
- Reordered the output of the logging columns ~~and split it over 2 lines because they were too long~~
- Removed `setup_logging` from everywhere it wasn't needed, it should not have been added anywhere except entry points.
- Runs as `LogLevel.INFO` as default, to reduce unnecessary `DEBUG` logging where not needed, unless the dev specifically wants it.
- Quick fix where `FloodType` is passed correctly from `tasks.py`, before it was being passed into the `landcover_scenario_gdf` param slot.

## Example files/log entries to show before and after:
### Regular Python
Before:
```
2026-07-21 17:08:30 | INFO     | __main__                        234 | scenario_folder_generator                          | Generating origin folder
```
[python_before.log](https://github.com/user-attachments/files/30213060/ce_direct_run_with_no_id.log)

After:
```
2026-07-21 17:00:16 | INFO     |  233 __main__                       | [task_id=-]
scenario_folder_generator                          | Generating origin folder
```
[python_after.log](https://github.com/user-attachments/files/30213065/ce_direct_run_with_id_logs.log)
### Celery/Docker
Before: 
```
celery_worker_digital_twin  | [2026-07-21 05:06:23,184: INFO/MainProcess] Matching model parameters found, output id 1
```
[celery_before.log](https://github.com/user-attachments/files/30213093/celery_worker_with_no_id.log)

After:
```
celery_worker_digital_twin  | 2026-07-21 04:53:21 | INFO     |   75 eddie.digitaltwin.check_cache_results | [task_id=d0521b8b-73aa-4e22-8daa-bac1ed51241a]
celery_worker_digital_twin  | main                                               | Matching model parameters found, output id 1
```
[celery_after.log](https://github.com/user-attachments/files/30213095/celery_worker_with_id.log)
