### PR TITLE
160 allow multiple people to run models at the same time

### DIFF
--- a/src/celery_worker_entrypoint.sh
+++ b/src/celery_worker_entrypoint.sh
@@ -8,4 +8,4 @@ source /venv/bin/activate
 # Run health-checker application, which reports back on the health of this container.
 # And in parallel run the celery workers
 health-checker --listener 0.0.0.0:5001 --log-level error --script-timeout 10 --script "celery -A src.eddie_floodresilience.tasks inspect ping"  \
-& celery -A src.eddie_floodresilience.tasks worker -P threads --loglevel=INFO
+& celery -A src.eddie_floodresilience.tasks worker -P gevent --loglevel=INFO

--- a/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
@@ -140,7 +140,12 @@ class WflowServeDataGenerator:
             clipped_landcover.rio.to_raster(clipped_path)
 
         layer_name = f"landcover_{self.flood_model_output_id}"
-        if layer_name not in gs.raster_layers.get_workspace_raster_layers(workspace_name):
+        if layer_name in gs.raster_layers.get_workspace_raster_layers(workspace_name):
+            # This can happen if the database is not in sync with geoserver. Better to allow it to continue.
+            # This is only likely to happen on development machines in very particular cases..
+            log.warning(f"{workspace_name}:{layer_name} already exists. Skipping adding {landcover_file}")
+        else:
+            # Add the landcover raster to geoserver
             coverage_dimensions = [CoverageDimension(layer_name, "landcover_class", "Int32")]
             gs.add_gtiff_to_geoserver(clipped_path, workspace_name, layer_name, coverage_dimensions)
         # Delete tmp clipped file

--- a/src/pywps.cfg
+++ b/src/pywps.cfg
@@ -27,8 +27,8 @@ outputpath=tmp/pywps/outputs
 workdir=tmp/pywps/workdir
 wd_inp_subdir=tmp/pywps/inputs
 wd_out_subdir=tmp/pywps/outputs
-maxprocesses=10
-parallelprocesses=2
+maxprocesses=-1
+parallelprocesses=-1
 
 [processing]
 mode=docker


### PR DESCRIPTION
Unlocks concurrency for more than 2 parallel processes.
This allows for potentially limitless tasks running at once.

If many tasks are running at once thee potential issues can arise:
  - Race-conditions when replacing geoserver layers from multiple tasks
  - All CPU resources used up running multiple CPU-intensive workflows at once (e.g. 8 instances of LISFLOOD not taking their time)
  
 Both of these are to be resolved as part of #102, where we can share sub-tasks between gevent threads and pre-fork pooling.
 