### PR TITLE
165 add lcdb landcover style so that it displays correctly on front end

### DIFF
--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
@@ -605,7 +605,7 @@ def otautau(
 #     vectors = None # r'vectors/vectors.csv'
 #     resolution = 200
 #     threshold = 25000
-#     landcover = 'globcover'
+#     landcover = 'lcdb'
 #
 #     # Set up hydraulic and hydrodynamic pipeline
 #     hydrological_hydrodynamic_pipeline = HydrologicalAndHydrodynamicPipeline(
@@ -823,7 +823,7 @@ def riverton(
     vectors = elevation_scenario_df  # r'vectors/vectors.csv'
     resolution = 200
     threshold = 25000
-    landcover = 'globcover'
+    landcover = 'lcdb'
 
     # Set up hydraulic and hydrodynamic pipeline
     hydrological_hydrodynamic_pipeline = HydrologicalAndHydrodynamicPipeline(

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
@@ -484,7 +484,7 @@ def landcover_catalog(scenario_id: int, scenario_name: str) -> dict:
         "name": f"Landcover - {scenario_name}",
         "url": gs_landcover_url,
         "layers": layer_name,
-        "styles": "landcover",
+        "styles": "globcover_landcover",
     }
 
 

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
@@ -28,7 +28,7 @@ from pywps.response.execute import ExecuteResponse
 
 from src.eddie_floodresilience import tasks
 from src.eddie_floodresilience.config import EnvVariable as EnvVar
-from src.eddie_floodresilience.solutions.total_solutions import GLOBCOVER_CLASSES
+from src.eddie_floodresilience.solutions.total_solutions import LCDB_CLASSES
 
 
 class PredefinedScenario(Process, ABC):
@@ -60,7 +60,7 @@ class PredefinedScenario(Process, ABC):
                     "landcover",
                     "Landcover Class",
                     data_type="string",
-                    allowed_values=list(GLOBCOVER_CLASSES.keys())
+                    allowed_values=list(LCDB_CLASSES.keys())
                 ),
             ]
         # Create area WPS outputs
@@ -484,7 +484,7 @@ def landcover_catalog(scenario_id: int, scenario_name: str) -> dict:
         "name": f"Landcover - {scenario_name}",
         "url": gs_landcover_url,
         "layers": layer_name,
-        "styles": "globcover_landcover",
+        "styles": "lcdb_landcover",
     }
 
 

--- a/src/eddie_floodresilience/solutions/total_solutions.py
+++ b/src/eddie_floodresilience/solutions/total_solutions.py
@@ -45,6 +45,18 @@ GLOBCOVER_CLASSES: dict[str, int] = {
     "Bare Land": 200,
 }
 
+LCDB_CLASSES: dict[str, int] = {
+    "High producing Exotic Grassland": 40,
+    "Low Producing Grassland": 41,
+    "Herbaceous Freshwater Vegetation": 45,
+    "Manuka and/or Kanuka": 52,
+    "Broadleaved Indigenous Hardwoods": 54,
+    "Forest - Harvested": 64,
+    "Deciduous Hardwoods": 68,
+    "Indigenous Forest": 69,
+    "Exotic Forest (needleleaf forest)": 71,
+}
+
 wbe = WbEnvironment()
 wbe.verbose = True
 wbe.max_procs = -1
@@ -109,7 +121,7 @@ class LandCoverSolution:
         # Copy original land cover data to not be affected by the change
         modified_landcover = current_landcover.copy()
         if "landcover" not in polygons.columns:
-            polygons["landcover"] = polygons["landcover_name"].map(GLOBCOVER_CLASSES)
+            polygons["landcover"] = polygons["landcover_name"].map(LCDB_CLASSES)
 
         # Create rasterization shapes
         shapes = [

--- a/src/static/geo/globcover_landcover.sld
+++ b/src/static/geo/globcover_landcover.sld
@@ -7,7 +7,7 @@
             <sld:FeatureTypeConstraint/>
         </sld:LayerFeatureConstraints>
         <sld:UserStyle>
-            <sld:Name>wflow_landuse</sld:Name>
+            <sld:Name>globcover_landcover</sld:Name>
             <sld:FeatureTypeStyle>
                 <sld:Rule>
                     <sld:RasterSymbolizer>

--- a/src/static/geo/lcdb_landcover.sld
+++ b/src/static/geo/lcdb_landcover.sld
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" version="1.0.0" xmlns:gml="http://www.opengis.net/gml"
+                       xmlns:ogc="http://www.opengis.net/ogc" xmlns:sld="http://www.opengis.net/sld">
+    <!--Style definition for Globcover Landcover rasters -->
+    <UserLayer>
+        <sld:LayerFeatureConstraints>
+            <sld:FeatureTypeConstraint/>
+        </sld:LayerFeatureConstraints>
+        <sld:UserStyle>
+            <sld:Name>lcdb_landcover</sld:Name>
+            <sld:FeatureTypeStyle>
+                <sld:Rule>
+                    <sld:RasterSymbolizer>
+                        <sld:ChannelSelection>
+                            <sld:GrayChannel>
+                                <sld:SourceChannelName>1</sld:SourceChannelName>
+                            </sld:GrayChannel>
+                        </sld:ChannelSelection>
+                        <sld:ColorMap type="values">
+                            <sld:ColorMapEntry color="#e69f00" label="High producing Exotic Grassland" quantity="40"/>
+                            <sld:ColorMapEntry color="#f0b84d" label="Low Producing Grassland" quantity="41"/>
+                            <sld:ColorMapEntry color="#4a90e2" label="Herbaceous Freshwater Vegetation" quantity="45"/>
+                            <sld:ColorMapEntry color="#a5be00" label="Manuka and/or Kanuka" quantity="52"/>
+                            <sld:ColorMapEntry color="#38b000" label="Broadleaved Indigenous Hardwoods" quantity="54"/>
+                            <sld:ColorMapEntry color="#c7c7a6" label="Forest - Harvested" quantity="64"/>
+                            <sld:ColorMapEntry color="#00441b" label="Deciduous Hardwoods" quantity="68"/>
+                            <sld:ColorMapEntry color="#007200" label="Indigenous Forest" quantity="69"/>
+                            <sld:ColorMapEntry color="#66BB6A" label="Exotic Forest (needleleaf forest)" quantity="71"/>
+                        </sld:ColorMap>
+                    </sld:RasterSymbolizer>
+                </sld:Rule>
+            </sld:FeatureTypeStyle>
+        </sld:UserStyle>
+    </UserLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
Globcover was the previous main landcover class type we used. Now we are primarily using LCDB, but the class numbers do not match.

This was causing bugs where most the the landcover was transparent, except for "High producing Exotic Grassland": 40 which was being displayed as "Evergreen Forest": 40

This PR add styles for LCDB, and makes it so that we use LCDB in the front-end at all times.

<img width="1470" height="851" alt="image" src="https://github.com/user-attachments/assets/c19402e3-2180-4c9e-bbb9-320645aff9b6" />
