### PR TITLE
Refactor Landcover classes to Enum

### DIFF
--- a/src/eddie_floodresilience/flood_model/bgflood/bgflood_parameters_generator.py
+++ b/src/eddie_floodresilience/flood_model/bgflood/bgflood_parameters_generator.py
@@ -23,6 +23,7 @@ from textwrap import dedent
 
 import geopandas as gpd
 import numpy as np
+import pandas as pd
 from shapely.geometry import Polygon, Point
 
 from ..flood_model_parameters_generator import FloodType, FloodModelParametersGenerator
@@ -44,13 +45,13 @@ class BGFloodParametersGenerator(FloodModelParametersGenerator):
         Starting time details. Format is "yyyy-mm-ddThh:mm:ss"
     end_time : datetime
         Ending time details.
-    polygons : str = None
-        Name of polygon file that is used to change the landcover information.
+    polygons : gpd.GeoDataFrame | None = None
         This polygon dataframe has 'landcover' column with new values
-    vectors : str = None
-        Name of vector file that is used to change the elevation information.
-        This vector dataframe has 'value' column to specify increasing or decreasing elevation,
-        and 'distance' column to specify how smooth to decrease elevation.
+    vectors : pd.DataFrame | None = None
+        Dataframe that contains 'vector_path', 'value', 'distance' columns:
+        - 'vector_path': Column that stores directories to specific vectors
+        - 'value: Column that stores value of the vectors used to increase/decrease elevation
+        - 'distance': Column that stores value to smooth the decreased elevation
     injection_points_flow : pd.DataFrame
         The flow data for each point
     injection_points : gpd.GeoDataFrame
@@ -65,8 +66,8 @@ class BGFloodParametersGenerator(FloodModelParametersGenerator):
         start_time: datetime,
         end_time: datetime,
         flood_type: FloodType = FloodType.FLUVIAL,
-        polygons: str = None,
-        vectors: str = None
+        polygons: gpd.GeoDataFrame | None = None,
+        vectors: pd.DataFrame | None = None
     ) -> None:
         """
         Generate parameter files for flood model
@@ -85,13 +86,13 @@ class BGFloodParametersGenerator(FloodModelParametersGenerator):
             Ending time details.
         flood_type : FloodType = FloodType.FLUVIAL
             Either FLUVIAL or PLUVIAL. Default is FLUVIAL
-        polygons : str = None
-            Name of polygon file that is used to change the landcover information.
+        polygons : gpd.GeoDataFrame | None = None
             This polygon dataframe has 'landcover' column with new values
-        vectors : str = None
-            Name of vector file that is used to change the elevation information.
-            This vector dataframe has 'value' column to specify increasing or decreasing elevation,
-            and 'distance' column to specify how smooth to decrease elevation.
+        vectors : pd.DataFrame | None = None
+            Dataframe that contains 'vector_path', 'value', 'distance' columns:
+            - 'vector_path': Column that stores directories to specific vectors
+            - 'value: Column that stores value of the vectors used to increase/decrease elevation
+            - 'distance': Column that stores value to smooth the decreased elevation
         """
         super().__init__(
             flood_model_path,

--- a/src/eddie_floodresilience/flood_model/flood_model_inputs_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_inputs_generator.py
@@ -39,8 +39,8 @@ class TerrainGenerator:
         hydromt_path: Path,
         river_name: str,
         aoi_boundary: list,
-        polygons: str = None,
-        vectors: pd.DataFrame = None,
+        polygons: gpd.GeoDataFrame | None = None,
+        vectors: pd.DataFrame | None = None,
         crs: int = 2193
     ) -> None:
         """
@@ -57,13 +57,13 @@ class TerrainGenerator:
         aoi_boundary : list
             Boundaries' coordinates of area of interest.
             Format is [xmin, ymin, xmax, ymax]
-        polygons : str = None
-            Name of polygon file that is used to change the landcover information.
+        polygons : gpd.GeoDataFrame | None = None
             This polygon dataframe has 'landcover' column with new values
-        vectors : pd.DataFrame = None
-            Name of vector file that is used to change the elevation information.
-            This vector dataframe has 'value' column to specify increasing or decreasing elevation,
-            and 'distance' column to specify how smooth to decrease elevation.
+        vectors : pd.DataFrame | None = None
+            Dataframe that contains 'vector_path', 'value', 'distance' columns:
+            - 'vector_path': Column that stores directories to specific vectors
+            - 'value: Column that stores value of the vectors used to increase/decrease elevation
+            - 'distance': Column that stores value to smooth the decreased elevation
         crs : int = 2193
             Targeted crs. The default is 2193 for NZTM.
         """
@@ -607,7 +607,7 @@ class InjectionPointsFloodModelGenerator:
         start_time: datetime,
         end_time: datetime,
         scenario_and_id_folder: Path,
-        polygons: str = None,
+        polygons: gpd.GeoDataFrame | None = None,
         crs: int = 2193
     ) -> None:
         """
@@ -623,8 +623,7 @@ class InjectionPointsFloodModelGenerator:
             Ending time details. Format is Dataframe that contains rivers' flow data at injection points
         scenario_and_id_folder : Path
             Directory to the scenario folder name with ID
-        polygons : str = None
-            Name of polygon file that is used to change the landcover information.
+        polygons : gpd.GeoDataframe | None = None
             This polygon dataframe has 'landcover' column with new values
         crs : int = 2193
             Targeted crs. The default is 2193 for NZTM.

--- a/src/eddie_floodresilience/flood_model/flood_model_parameters_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_parameters_generator.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
 
+import geopandas as gpd
 import pandas as pd
 from shapely.geometry import Polygon
 
@@ -46,8 +47,8 @@ class FloodModelParametersGenerator(ABC):
         start_time: datetime,
         end_time: datetime,
         flood_type: str = 'fluvial',
-        polygons: str = None,
-        vectors: pd.DataFrame = None
+        polygons: gpd.GeoDataFrame | None = None,
+        vectors: pd.DataFrame | None = None
     ) -> None:
         """
         Generate parameter files for flood model
@@ -66,13 +67,13 @@ class FloodModelParametersGenerator(ABC):
             Ending time details.
         flood_type : FloodType = FloodType.FLUVIAL
             Either FLUVIAL or PLUVIAL. Default is FLUVIAL
-        polygons : str = None
-            Name of polygon file that is used to change the landcover information.
+        polygons : gpd.GeoDataFrame | None = None
             This polygon dataframe has 'landcover' column with new values
-        vectors : pd.DataFrame = None
-            Name of vector file that is used to change the elevation information.
-            This vector dataframe has 'value' column to specify increasing or decreasing elevation,
-            and 'distance' column to specify how smooth to decrease elevation.
+        vectors : pd.DataFrame | None = None
+            Dataframe that contains 'vector_path', 'value', 'distance' columns:
+            - 'vector_path': Column that stores directories to specific vectors
+            - 'value: Column that stores value of the vectors used to increase/decrease elevation
+            - 'distance': Column that stores value to smooth the decreased elevation
         """
         self.flood_model_path = flood_model_path
         self.hydromt_path = hydromt_path

--- a/src/eddie_floodresilience/flood_model/flood_model_precipitation.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_precipitation.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import netCDF4
 import numpy as np
 import xarray as xr
+from shapely import Polygon
 from tqdm import tqdm
 from rasterio.enums import Resampling
 
@@ -37,7 +38,7 @@ class PrecipitationGenerator:
         self,
         flood_model_path: Path,
         precipitation_path: Path,
-        terrain_bounding_box: xr.Dataset,
+        terrain_bounding_box: Polygon,
         start_time: datetime,
         end_time: datetime,
         crs: int = 2193

--- a/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/flood_model_siumulations_generator.py
@@ -60,8 +60,8 @@ class BaseFloodModelSimulationsGenerator(ABC):
         scenario_and_id_folder: Path,
         flood_type: FloodType = FloodType.FLUVIAL,
         crs: int = 2193,
-        polygons: str = None,
-        vectors: pd.DataFrame = None
+        polygons: gpd.GeoDataFrame | None = None,
+        vectors: pd.DataFrame | None = None
     ) -> None:
         """
         Generate flood model simulations
@@ -90,13 +90,13 @@ class BaseFloodModelSimulationsGenerator(ABC):
             Either FLUVIAL or PLUVIAL. Default is FLUVIAL
         crs : int = 2193
             Targeted crs. The default is 2193 for NZTM.
-        polygons : str = None
-            Name of polygon file that is used to change the landcover information.
+        polygons : gpd.GeoDataFrame | None = None
             This polygon dataframe has 'landcover' column with new values
-        vectors : pd.DataFrame = None
-            Name of vector file that is used to change the elevation information.
-            This vector dataframe has 'value' column to specify increasing or decreasing elevation,
-            and 'distance' column to specify how smooth to decrease elevation.
+        vectors : pd.DataFrame | None = None
+            Dataframe that contains 'vector_path', 'value', 'distance' columns:
+            - 'vector_path': Column that stores directories to specific vectors
+            - 'value: Column that stores value of the vectors used to increase/decrease elevation
+            - 'distance': Column that stores value to smooth the decreased elevation
         """
         self.hydromt_path = hydromt_path
         self.river_name = river_name

--- a/src/eddie_floodresilience/flood_model/lisflood/lisflood_inputs_generator.py
+++ b/src/eddie_floodresilience/flood_model/lisflood/lisflood_inputs_generator.py
@@ -42,7 +42,7 @@ class TerrainFloodModelGenerator:
         river_name: str,
         terrain_crs_clipped: xr.Dataset,
         adjust_manning: bool,
-        vectors: pd.DataFrame = None,
+        vectors: pd.DataFrame | None = None,
         crs: int = 2193
     ) -> None:
         """
@@ -61,10 +61,11 @@ class TerrainFloodModelGenerator:
         adjust_manning : bool
             True means adjusting Manning's n by resampling 4m Manning's n
             False means no Mannning's n adjustment
-        vectors : pd.DataFrame = None
-            Name of vector file that is used to change the elevation information.
-            This vector dataframe has 'value' column to specify increasing or decreasing elevation,
-            and 'distance' column to specify how smooth to decrease elevation.
+        vectors : pd.DataFrame | None = None
+            Dataframe that contains 'vector_path', 'value', 'distance' columns:
+            - 'vector_path': Column that stores directories to specific vectors
+            - 'value: Column that stores value of the vectors used to increase/decrease elevation
+            - 'distance': Column that stores value to smooth the decreased elevation
         crs : int = 2193
             Targeted crs. The default is 2193 for NZTM.
         """

--- a/src/eddie_floodresilience/flood_model/lisflood/lisflood_simulations_generator.py
+++ b/src/eddie_floodresilience/flood_model/lisflood/lisflood_simulations_generator.py
@@ -140,9 +140,9 @@ class LisFloodModelSimulationsGenerator(BaseFloodModelSimulationsGenerator):
 
         # Flood simulation command
         flood_simulation_command = [
-            lisflood_path,
+            str(lisflood_path),
             "-v",
-            par_file_path
+            str(par_file_path)
         ]
 
         # Generate flood model simulations

--- a/src/eddie_floodresilience/hydrological/wflow_build_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_build_generator.py
@@ -7,10 +7,11 @@ Created on Thu Apr  9 09:01:33 2026
 
 import json
 import logging
-from pathlib import Path
 from datetime import datetime
-from dateutil.relativedelta import relativedelta
+from pathlib import Path
 
+from dateutil.relativedelta import relativedelta
+import geopandas as gpd
 import yaml
 
 log = logging.getLogger(__name__)
@@ -41,8 +42,7 @@ class WflowBuildGenerator:
         A directory to where the forcing files are stored
     scenario_and_id_folder : Path
             Directory to the scenario folder name with ID
-    polygons : str = None
-        Name of polygon file that is used to change the landcover information.
+    polygons : gpd.GeoDataFrame | None = None
         This polygon dataframe has 'landcover' column with new values
     landcover : str = 'globcover'
         Name of land cover dataset. Default is globcover
@@ -57,7 +57,7 @@ class WflowBuildGenerator:
         river_name: str,
         forcing_path: Path,
         scenario_and_id_folder: Path,
-        polygons: str = None,
+        polygons: gpd.GeoDataFrame = None,
         landcover: str = 'globcover'
     ) -> None:
         """
@@ -86,8 +86,7 @@ class WflowBuildGenerator:
             A directory to where the forcing files are stored
         scenario_and_id_folder : Path
             Directory to the scenario folder name with ID
-        polygons : str = None
-            Name of polygon file that is used to change the landcover information.
+        polygons : gpd.GeoDataFrame | None = None
             This polygon dataframe has 'landcover' column with new values
         landcover : str = 'globcover'
             Name of land cover dataset. Default is global cover

--- a/src/eddie_floodresilience/hydrological/wflow_build_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_build_generator.py
@@ -14,6 +14,8 @@ from dateutil.relativedelta import relativedelta
 import geopandas as gpd
 import yaml
 
+from src.eddie_floodresilience.solutions.landcover import LandcoverClassDataset
+
 log = logging.getLogger(__name__)
 
 
@@ -44,7 +46,7 @@ class WflowBuildGenerator:
             Directory to the scenario folder name with ID
     polygons : gpd.GeoDataFrame | None = None
         This polygon dataframe has 'landcover' column with new values
-    landcover : str = 'globcover'
+    landcover : LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER = 'globcover'
         Name of land cover dataset. Default is globcover
     """  # pylint: disable=too-many-instance-attributes
 
@@ -58,7 +60,7 @@ class WflowBuildGenerator:
         forcing_path: Path,
         scenario_and_id_folder: Path,
         polygons: gpd.GeoDataFrame = None,
-        landcover: str = 'globcover'
+        landcover: LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER
     ) -> None:
         """
         Generate wflow_build.yml for preprocessing data for wflow.
@@ -88,7 +90,7 @@ class WflowBuildGenerator:
             Directory to the scenario folder name with ID
         polygons : gpd.GeoDataFrame | None = None
             This polygon dataframe has 'landcover' column with new values
-        landcover : str = 'globcover'
+        landcover : LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER = 'globcover'
             Name of land cover dataset. Default is global cover
         """
         self.start_time = start_time - relativedelta(months=2)
@@ -252,10 +254,11 @@ class WflowBuildGenerator:
         lulc : dict
             A dictionary that contains landcover's section
         """
-        if self.landcover.startswith("globcover"):
-            landcover_mapping = str(self.hydromt_path / "globcover_mapping_modified.csv")
-        else:
-            landcover_mapping = str(self.hydromt_path / "lcdb_mapping.csv")
+        match self.landcover:
+            case LandcoverClassDataset.GLOBCOVER:
+                landcover_mapping = str(self.hydromt_path / "globcover_mapping_modified.csv")
+            case LandcoverClassDataset.LCDB:
+                landcover_mapping = str(self.hydromt_path / "lcdb_mapping.csv")
 
         # Generate landuse/landcover's section
         landcover = {
@@ -277,7 +280,7 @@ class WflowBuildGenerator:
             A dictionary that contains lai's section
         """
         # Set up lulc_zero_classes
-        if self.landcover.startswith("globcover"):
+        if self.landcover == LandcoverClassDataset.GLOBCOVER:
             lulc_zero_classes = [200, 210, 220]
         else:
             lulc_zero_classes = [14, 20, 21, 22]

--- a/src/eddie_floodresilience/hydrological/wflow_data_catalog_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_data_catalog_generator.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import yaml
 import geopandas as gpd
 
+from src.eddie_floodresilience.solutions.landcover import LandcoverClassDataset
+
 log = logging.getLogger(__name__)
 
 
@@ -24,7 +26,7 @@ class DataCatalogGenerator:
         river_name: str,
         scenario_and_id_folder: Path,
         polygons: gpd.GeoDataFrame | None = None,
-        landcover: str = 'globcover'
+        landcover: LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER
     ) -> None:
         """
         Generate data_catalog.yml for preprocessing data for wflow.
@@ -44,7 +46,7 @@ class DataCatalogGenerator:
         polygons : gpd.GeoDataFrame | None = None
             Polygons that are used to change the landcover information.
             This polygon dataframe has 'landcover' column with new values
-        landcover : str = 'globcover'
+        landcover : LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER = 'globcover'
             Name of land cover. Default is 'globcover'
         """
         self.hydromt_path = hydromt_path
@@ -53,27 +55,6 @@ class DataCatalogGenerator:
         self.scenario_and_id_folder = scenario_and_id_folder
         self.polygons = polygons
         self.landcover = landcover
-
-    @staticmethod
-    def landcover_mapping_type(landcover: str) -> str:
-        """
-        Identify what type of landcover data source is being used.
-
-        Parameters
-        ----------
-        landcover : str
-            Name of land cover.
-
-        Returns
-        ----------
-        str
-            Name of landcover dataset - globcover or lcdb
-        """
-        if landcover.startswith('globcover'):
-            landcover_mapping_type = 'globcover'
-        else:
-            landcover_mapping_type = 'lcdb'
-        return landcover_mapping_type
 
     def meta_section(self) -> dict:
         """
@@ -177,13 +158,11 @@ class DataCatalogGenerator:
         landcover : dict
             A dictionary contains information of landcover
         """
-        landcover_mapping_type = self.landcover_mapping_type(self.landcover)
-
         # Check landcover path
         is_baseline = self.polygons is None
         landcover_file = find_landcover_file(
             self.hydromt_path,
-            landcover_mapping_type,
+            self.landcover,
             self.scenario_and_id_folder,
             is_baseline
         )
@@ -487,7 +466,7 @@ class DataCatalogGenerator:
 
 def find_landcover_file(
     hydromt_path: Path,
-    landcover_mapping_type: str,
+    landcover_mapping_type: LandcoverClassDataset,
     scenario_and_id_folder: Path,
     is_baseline: bool = True
 ) -> Path:
@@ -498,7 +477,7 @@ def find_landcover_file(
     ----------
     hydromt_path : Path
         A directory to where all necessary files are stored to run wflow model
-    landcover_mapping_type : str
+    landcover_mapping_type : LandcoverClassDataset
         Name of landcover dataset - globcover or lcdb
     scenario_and_id_folder : Path
         Directory to the scenario folder name with ID

--- a/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_serve_data_generator.py
@@ -31,6 +31,7 @@ from eddie.digitaltwin import setup_environment
 from eddie.geoserver.raster_layers import CoverageDimension
 from src.eddie_floodresilience.config import EnvVariable
 from src.eddie_floodresilience.hydrological.wflow_data_catalog_generator import find_landcover_file
+from src.eddie_floodresilience.solutions.landcover import LandcoverClassDataset
 
 log = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class WflowServeDataGenerator:
         self,
         hydromt_path: Path,
         polygons: gpd.GeoDataFrame | None,
-        landcover_mapping_type: str,
+        landcover_mapping_type: LandcoverClassDataset,
         scenario_and_id_folder: Path,
         flood_model_output_id: int
     ) -> None:
@@ -72,7 +73,7 @@ class WflowServeDataGenerator:
         polygons: gpd.GeoDataFrame | None
             Polygons that are used to change the landcover information.
             This polygon dataframe has 'landcover' column with new values
-        landcover_mapping_type : str
+        landcover_mapping_type : LandcoverClassDataset
             Name of landcover dataset - globcover or lcdb
         scenario_and_id_folder : Path
             Directory to the scenario folder name with ID

--- a/src/eddie_floodresilience/hydrological/wflow_simulations_generator.py
+++ b/src/eddie_floodresilience/hydrological/wflow_simulations_generator.py
@@ -27,6 +27,7 @@ import geopandas as gpd
 
 from .wflow_data_catalog_generator import DataCatalogGenerator
 from .wflow_build_generator import WflowBuildGenerator
+from ..solutions.landcover import LandcoverClassDataset
 
 log = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ class WflowSimulationsGenerator:
     resolution : float
         Resolution for flow data.
         Default is 0.00045 (in crs 4326) ~ 50 m (in crs 2193)
-    landcover : str = 'globcover'
+    landcover : LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER = 'globcover'
         Name of land cover dataset. Default is 'globcover'
     """  # pylint: disable=too-many-instance-attributes
 
@@ -80,7 +81,7 @@ class WflowSimulationsGenerator:
         scenario_and_id_folder: Path,
         polygons: gpd.GeoDataFrame | None = None,
         resolution: float = 0.00045,
-        landcover: str = 'globcover'
+        landcover: LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER
     ) -> None:
         """
         Generate wflow model simulations
@@ -114,7 +115,7 @@ class WflowSimulationsGenerator:
         resolution : float
             Resolution for flow data.
             Default is 0.00045 (in crs 4326) ~ 50 m (in crs 2193)
-        landcover : str = 'globcover'
+        landcover : LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER = 'globcover'
             Name of land cover dataset. Default is 'globcover'
         """
         self.hydromt_path = hydromt_path

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
@@ -26,10 +26,10 @@ from src.eddie_floodresilience.flood_model.bgflood.bgflood_simulations_generator
 from src.eddie_floodresilience.flood_model.flood_model_parameters_generator import FloodType
 from src.eddie_floodresilience.flood_model.lisflood.lisflood_simulations_generator import \
     LisFloodModelSimulationsGenerator
-from src.eddie_floodresilience.hydrological.wflow_data_catalog_generator import DataCatalogGenerator
 from src.eddie_floodresilience.hydrological.wflow_serve_data_generator import WflowServeDataGenerator
 from src.eddie_floodresilience.hydrological.wflow_simulations_generator import WflowSimulationsGenerator
 from src.eddie_floodresilience.preprocessing.terrain_data_for_wflow_generator import TerrainDataWflowGenerator
+from src.eddie_floodresilience.solutions.landcover import LandcoverClassDataset
 from src.eddie_floodresilience.solutions.total_solutions import LandCoverSolution, ElevationSolution
 from src.eddie_floodresilience.tables import PipelineOutput
 
@@ -85,7 +85,7 @@ class HydrologicalAndHydrodynamicPipeline:
         threshold: int = 1000
             Minimum number of cells/up-slope area required to initiate and main a channel.
             Default is 1000
-        landcover: str = 'globcover'
+        landcover: LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER
             Name of land cover dataset. Default is 'globcover'
     """  # pylint: disable=too-many-instance-attributes
 
@@ -110,7 +110,7 @@ class HydrologicalAndHydrodynamicPipeline:
         vectors: pd.DataFrame | None = None,
         resolution: float = 0.00045,
         threshold: int = 1000,
-        landcover: str = 'globcover'
+        landcover: LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER
     ) -> None:
         """
         Generate hydrological and hydrodynamic results
@@ -160,7 +160,7 @@ class HydrologicalAndHydrodynamicPipeline:
         threshold: int = 1000
             Minimum number of cells/up-slope area required to initiate and main a channel.
             Default is 1000
-        landcover: str = 'globcover'
+        landcover: LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER
             Name of land cover dataset. Default is 'globcover'
         """
         # Set up necessary parameters
@@ -270,8 +270,8 @@ class HydrologicalAndHydrodynamicPipeline:
         return scenario_and_id_folder
 
     def total_solutions(
-            self,
-            scenario_and_id_folder: Path
+        self,
+        scenario_and_id_folder: Path
     ) -> None:
         """
         Develop solutions for flood risk resilience
@@ -293,7 +293,7 @@ class HydrologicalAndHydrodynamicPipeline:
                 self.landcover,
                 self.polygons
             )
-            self.landcover = landcover_solution.apply_landcover_solution().name
+            landcover_solution.apply_landcover_solution()
 
             # Elevation solution
             elevation_solution = ElevationSolution(
@@ -312,7 +312,7 @@ class HydrologicalAndHydrodynamicPipeline:
                 self.landcover,
                 self.polygons
             )
-            self.landcover = landcover_solution.apply_landcover_solution().name
+            landcover_solution.apply_landcover_solution()
 
         elif self.vectors is not None:
 
@@ -346,8 +346,8 @@ class HydrologicalAndHydrodynamicPipeline:
         terrain_data.terrain_for_wflow_generator()
 
     def wflow_data_pipeline(
-            self,
-            scenario_and_id_folder: Path
+        self,
+        scenario_and_id_folder: Path
     ) -> None:
         """
         Generate wflow model data for flood model
@@ -388,11 +388,10 @@ class HydrologicalAndHydrodynamicPipeline:
         flood_model_output_id: int
             The flood model output ID to associate the WFlow data with
         """
-        landcover_mapping_type = DataCatalogGenerator.landcover_mapping_type(self.landcover)
         wflow_serve_data = WflowServeDataGenerator(
             self.hydromt_path,
             self.polygons,
-            landcover_mapping_type,
+            self.landcover,
             scenario_and_id_folder,
             flood_model_output_id
         )
@@ -400,8 +399,8 @@ class HydrologicalAndHydrodynamicPipeline:
         wflow_serve_data.serve_data()
 
     def flood_data_pipeline(
-            self,
-            scenario_and_id_folder: Path
+        self,
+        scenario_and_id_folder: Path
     ) -> int:
         """
         Generate flood model data.
@@ -516,9 +515,9 @@ class HydrologicalAndHydrodynamicPipeline:
 
 # OTAUTAU
 def otautau(
-        flood_type: FloodType = FloodType.FLUVIAL,
-        landcover_scenario_gdf: gpd.GeoDataFrame | None = None,
-        elevation_scenario_df: pd.DataFrame | None = None
+    flood_type: FloodType = FloodType.FLUVIAL,
+    landcover_scenario_gdf: gpd.GeoDataFrame | None = None,
+    elevation_scenario_df: pd.DataFrame | None = None
 ) -> int:
     """
     Run a hydrological and hydrodynamic simulation for Otautau.
@@ -558,7 +557,7 @@ def otautau(
     vectors = elevation_scenario_df  # r'vectors/vectors.csv'
     resolution = 200
     threshold = 25000
-    landcover = 'lcdb'
+    landcover = LandcoverClassDataset.LCDB
 
     # Set up hydraulic and hydrodynamic pipeline
     hydrological_hydrodynamic_pipeline = HydrologicalAndHydrodynamicPipeline(
@@ -607,7 +606,7 @@ def otautau(
 #     vectors = None # r'vectors/vectors.csv'
 #     resolution = 200
 #     threshold = 25000
-#     landcover = 'lcdb'
+#     landcover = LandcoverClassDataset.LCDB
 #
 #     # Set up hydraulic and hydrodynamic pipeline
 #     hydrological_hydrodynamic_pipeline = HydrologicalAndHydrodynamicPipeline(
@@ -638,9 +637,9 @@ def otautau(
 
 
 def mataura(
-        flood_type: FloodType = FloodType.FLUVIAL,
-        landcover_scenario_gdf: gpd.GeoDataFrame | None = None,
-        elevation_scenario_df: pd.DataFrame | None = None
+    flood_type: FloodType = FloodType.FLUVIAL,
+    landcover_scenario_gdf: gpd.GeoDataFrame | None = None,
+    elevation_scenario_df: pd.DataFrame | None = None
 ) -> int:
     """
     Run a hydrological and hydrodynamic simulation for Mataura.
@@ -680,7 +679,7 @@ def mataura(
     vectors = elevation_scenario_df  # r'vectors/vectors.csv'
     resolution = 200
     threshold = 25000
-    landcover = 'lcdb'
+    landcover = LandcoverClassDataset.LCDB
 
     # Set up hydraulic and hydrodynamic pipeline
     hydrological_hydrodynamic_pipeline = HydrologicalAndHydrodynamicPipeline(
@@ -711,9 +710,9 @@ def mataura(
 
 
 def whirinaki(
-        flood_type: FloodType = FloodType.FLUVIAL,
-        landcover_scenario_gdf: gpd.GeoDataFrame | None = None,
-        elevation_scenario_df: pd.DataFrame | None = None
+    flood_type: FloodType = FloodType.FLUVIAL,
+    landcover_scenario_gdf: gpd.GeoDataFrame | None = None,
+    elevation_scenario_df: pd.DataFrame | None = None
 ) -> int:
     """
     Run a hydrological and hydrodynamic simulation for Whirinaki.
@@ -752,7 +751,7 @@ def whirinaki(
     vectors = elevation_scenario_df  # r'vectors/vectors.csv'
     resolution = 50
     threshold = 1000
-    landcover = 'lcdb'
+    landcover = LandcoverClassDataset.LCDB
 
     # Set up hydraulic and hydrodynamic pipeline
     hydrological_hydrodynamic_pipeline = HydrologicalAndHydrodynamicPipeline(
@@ -784,9 +783,9 @@ def whirinaki(
 
 # RIVERTON
 def riverton(
-        flood_type: FloodType = FloodType.FLUVIAL,
-        landcover_scenario_gdf: gpd.GeoDataFrame | None = None,
-        elevation_scenario_df: pd.DataFrame | None = None
+    flood_type: FloodType = FloodType.FLUVIAL,
+    landcover_scenario_gdf: gpd.GeoDataFrame | None = None,
+    elevation_scenario_df: pd.DataFrame | None = None
 ) -> int:
     """
     Run a hydrological and hydrodynamic simulation for Riverton.
@@ -825,7 +824,7 @@ def riverton(
     vectors = elevation_scenario_df  # r'vectors/vectors.csv'
     resolution = 200
     threshold = 25000
-    landcover = 'lcdb'
+    landcover = LandcoverClassDataset.LCDB
 
     # Set up hydraulic and hydrodynamic pipeline
     hydrological_hydrodynamic_pipeline = HydrologicalAndHydrodynamicPipeline(

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_pipeline.py
@@ -22,15 +22,15 @@ from eddie.digitaltwin.tables import create_table
 from eddie.digitaltwin.utils import setup_logging, LogLevel
 
 from src.eddie_floodresilience.config import EnvVariable
-from src.eddie_floodresilience.flood_model.flood_model_parameters_generator import FloodType
-from src.eddie_floodresilience.hydrological.wflow_data_catalog_generator import DataCatalogGenerator
-from src.eddie_floodresilience.hydrological.wflow_serve_data_generator import WflowServeDataGenerator
-from src.eddie_floodresilience.solutions.total_solutions import LandCoverSolution, ElevationSolution
-from src.eddie_floodresilience.preprocessing.terrain_data_for_wflow_generator import TerrainDataWflowGenerator
-from src.eddie_floodresilience.hydrological.wflow_simulations_generator import WflowSimulationsGenerator
 from src.eddie_floodresilience.flood_model.bgflood.bgflood_simulations_generator import BGFloodModelSimulationsGenerator
+from src.eddie_floodresilience.flood_model.flood_model_parameters_generator import FloodType
 from src.eddie_floodresilience.flood_model.lisflood.lisflood_simulations_generator import \
     LisFloodModelSimulationsGenerator
+from src.eddie_floodresilience.hydrological.wflow_data_catalog_generator import DataCatalogGenerator
+from src.eddie_floodresilience.hydrological.wflow_serve_data_generator import WflowServeDataGenerator
+from src.eddie_floodresilience.hydrological.wflow_simulations_generator import WflowSimulationsGenerator
+from src.eddie_floodresilience.preprocessing.terrain_data_for_wflow_generator import TerrainDataWflowGenerator
+from src.eddie_floodresilience.solutions.total_solutions import LandCoverSolution, ElevationSolution
 from src.eddie_floodresilience.tables import PipelineOutput
 
 log = logging.getLogger(__name__)
@@ -74,10 +74,11 @@ class HydrologicalAndHydrodynamicPipeline:
         polygons : gpd.GeoDataFrame | None = None
             Polygons that are used to change the landcover information.
             This polygon dataframe has 'landcover' column with new values
-        vectors : pd.DataFrame = None
-            Name of vector file that is used to change the elevation information.
-            This vector dataframe has 'value' column to specify increasing or decreasing elevation,
-            and 'distance' column to specify how smooth to decrease elevation.
+        vectors : pd.DataFrame | None = None
+            Dataframe that contains 'vector_path', 'value', 'distance' columns:
+            - 'vector_path': Column that stores directories to specific vectors
+            - 'value: Column that stores value of the vectors used to increase/decrease elevation
+            - 'distance': Column that stores value to smooth the decreased elevation
         resolution : float
             Resolution for flow data.
             Default is 0.00045 (in crs 4326) ~ 50 m (in crs 2193)
@@ -93,7 +94,7 @@ class HydrologicalAndHydrodynamicPipeline:
         hydro_combination_path: Path,
 
         forcing_name: Union[str, Path],
-        river_name: Union[str, Path],
+        river_name: str,
         precipitation_path: Path,
         start_time: datetime,
         end_time: datetime,
@@ -106,7 +107,7 @@ class HydrologicalAndHydrodynamicPipeline:
         flood_type: FloodType = FloodType.FLUVIAL,
 
         polygons: gpd.GeoDataFrame | None = None,
-        vectors: pd.DataFrame = None,
+        vectors: pd.DataFrame | None = None,
         resolution: float = 0.00045,
         threshold: int = 1000,
         landcover: str = 'globcover'
@@ -121,15 +122,15 @@ class HydrologicalAndHydrodynamicPipeline:
         forcing_name: Union[str, Path]
             Name of forcing data. Should be the site name. Ex: 'whirin
             Or a directory to forcing data
-        river_name: Union[str, Path]
+        river_name: str
             Name of river data. Should be the site name. Ex: 'whirinaki'
         precipitation_path: Path
             A directory to where the precipitation files are stored
-        start_time : str
+        start_time : datetime
             Starting time of simulation.
             This should include the spin-up time.
             Normally, it is 1-year before the flood event.
-        end_time : str
+        end_time : datetime
             Ending time of simulation
             This should include some periods of time after the flood event.
             Normally, it is about 2-3 months.
@@ -148,10 +149,11 @@ class HydrologicalAndHydrodynamicPipeline:
         polygons : gpd.GeoDataFrame | None = None
             Polygons that are used to change the landcover information.
             This polygon dataframe has 'landcover' column with new values
-        vectors : pd.DataFrame = None
-            Name of vector file that is used to change the elevation information.
-            This vector dataframe has 'value' column to specify increasing or decreasing elevation,
-            and 'distance' column to specify how smooth to decrease elevation.
+        vectors : pd.DataFrame | None = None
+            Dataframe that contains 'vector_path', 'value', 'distance' columns:
+            - 'vector_path': Column that stores directories to specific vectors
+            - 'value: Column that stores value of the vectors used to increase/decrease elevation
+            - 'distance': Column that stores value to smooth the decreased elevation
         resolution : float
             Resolution for flow data.
             Default is 0.00045 (in crs 4326) ~ 50 m (in crs 2193)
@@ -434,7 +436,6 @@ class HydrologicalAndHydrodynamicPipeline:
             )
 
         else:
-            # pylint: disable=E1121
             flood_data = BGFloodModelSimulationsGenerator(
                 self.hydromt_path,
                 self.river_name,
@@ -585,6 +586,7 @@ def otautau(
 
     flood_model_output_id = hydrological_hydrodynamic_pipeline.hydrological_and_hydrodynamic_simulation_generator()
     return flood_model_output_id
+
 
 # # WAIMEA
 # def main():

--- a/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
+++ b/src/eddie_floodresilience/hydrological_and_hydrodynamic_service.py
@@ -28,7 +28,7 @@ from pywps.response.execute import ExecuteResponse
 
 from src.eddie_floodresilience import tasks
 from src.eddie_floodresilience.config import EnvVariable as EnvVar
-from src.eddie_floodresilience.solutions.total_solutions import LCDB_CLASSES
+from src.eddie_floodresilience.solutions.landcover import LCDB_CLASSES
 
 
 class PredefinedScenario(Process, ABC):

--- a/src/eddie_floodresilience/solutions/__init__.py
+++ b/src/eddie_floodresilience/solutions/__init__.py
@@ -1,0 +1,18 @@
+# # -*- coding: utf-8 -*-
+# Copyright © 2021-2026 Geospatial Research Institute Toi Hangarau
+# LICENSE: https://github.com/GeospatialResearch/Digital-Twins/blob/master/LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Package contains modules related to solutions that can build up to a scenario."""

--- a/src/eddie_floodresilience/solutions/landcover.py
+++ b/src/eddie_floodresilience/solutions/landcover.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2021-2026 Geospatial Research Institute Toi Hangarau
+# LICENSE: https://github.com/GeospatialResearch/Digital-Twins/blob/master/LICENSE
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Provides definitions of landcover class value mappings."""
+
+GLOBCOVER_CLASSES: dict[str, int] = {
+    "Dense Deciduous Forest": 50,
+    "Evergreen Forest": 40,
+    "Deciduous Forest": 60,
+    "Needleleaf Forest": 70,
+    "Pasture Mosaic": 120,
+    "Shrubland": 130,
+    "Pasture": 140,
+    "Sparse Vegetation": 150,
+    "Wetland": 160,
+    "Bare Land": 200,
+}
+
+LCDB_CLASSES: dict[str, int] = {
+    "High Producing Exotic Grassland": 40,
+    "Low Producing Grassland": 41,
+    "Herbaceous Freshwater Vegetation": 45,
+    "Manuka and/or Kanuka": 52,
+    "Broadleaved Indigenous Hardwoods": 54,
+    "Forest - Harvested": 64,
+    "Deciduous Hardwoods": 68,
+    "Indigenous Forest": 69,
+    "Exotic Forest (needleleaf forest)": 71,
+}

--- a/src/eddie_floodresilience/solutions/landcover.py
+++ b/src/eddie_floodresilience/solutions/landcover.py
@@ -16,6 +16,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Provides definitions of landcover class value mappings."""
+from enum import StrEnum
+
+
+class LandcoverClassDataset(StrEnum):
+    """Specifies which Land cover dataset is being used"""
+
+    GLOBCOVER = "globcover"
+    LCDB = "lcdb"
+
 
 GLOBCOVER_CLASSES: dict[str, int] = {
     "Dense Deciduous Forest": 50,

--- a/src/eddie_floodresilience/solutions/total_solutions.py
+++ b/src/eddie_floodresilience/solutions/total_solutions.py
@@ -205,7 +205,7 @@ class ElevationSolution:
         self,
         flood_model: str,
         scenario_and_id_folder: Path,
-        vectors: pd.DataFrame = None
+        vectors: pd.DataFrame | None = None
     ) -> None:
         """
         Change the elevation based on the vector.
@@ -220,8 +220,8 @@ class ElevationSolution:
             Either "lisflood-fp" or "bg-flood"
         scenario_and_id_folder : Path
             Directory to the scenario folder name with ID
-        vectors : pd.DataFrame = None
-            Name of dataframe that contains 'vector_path', 'value', 'distance' columns:
+        vectors : pd.DataFrame | None = None
+            Dataframe that contains 'vector_path', 'value', 'distance' columns:
             - 'vector_path': Column that stores directories to specific vectors
             - 'value: Column that stores value of the vectors used to increase/decrease elevation
             - 'distance': Column that stores value to smooth the decreased elevation

--- a/src/eddie_floodresilience/solutions/total_solutions.py
+++ b/src/eddie_floodresilience/solutions/total_solutions.py
@@ -29,33 +29,9 @@ from scipy.ndimage import distance_transform_edt
 from whitebox.whitebox_tools import WhiteboxTools
 from whitebox_workflows import WbEnvironment
 
+from src.eddie_floodresilience.solutions.landcover import LCDB_CLASSES
 
 log = logging.getLogger(__name__)
-
-GLOBCOVER_CLASSES: dict[str, int] = {
-    "Dense Deciduous Forest": 50,
-    "Evergreen Forest": 40,
-    "Deciduous Forest": 60,
-    "Needleleaf Forest": 70,
-    "Pasture Mosaic": 120,
-    "Shrubland": 130,
-    "Pasture": 140,
-    "Sparse Vegetation": 150,
-    "Wetland": 160,
-    "Bare Land": 200,
-}
-
-LCDB_CLASSES: dict[str, int] = {
-    "High producing Exotic Grassland": 40,
-    "Low Producing Grassland": 41,
-    "Herbaceous Freshwater Vegetation": 45,
-    "Manuka and/or Kanuka": 52,
-    "Broadleaved Indigenous Hardwoods": 54,
-    "Forest - Harvested": 64,
-    "Deciduous Hardwoods": 68,
-    "Indigenous Forest": 69,
-    "Exotic Forest (needleleaf forest)": 71,
-}
 
 wbe = WbEnvironment()
 wbe.verbose = True

--- a/src/eddie_floodresilience/solutions/total_solutions.py
+++ b/src/eddie_floodresilience/solutions/total_solutions.py
@@ -29,10 +29,11 @@ from scipy.ndimage import distance_transform_edt
 from whitebox.whitebox_tools import WhiteboxTools
 from whitebox_workflows import WbEnvironment
 
-from src.eddie_floodresilience.solutions.landcover import LCDB_CLASSES
+from src.eddie_floodresilience.solutions.landcover import LandcoverClassDataset, LCDB_CLASSES
 
 log = logging.getLogger(__name__)
 
+# pylint: disable=duplicate-code
 wbe = WbEnvironment()
 wbe.verbose = True
 wbe.max_procs = -1
@@ -47,7 +48,7 @@ class LandCoverSolution:
         self,
         hydromt_path: Path,
         scenario_and_id_folder: Path,
-        landcover: str = 'globcover',
+        landcover: LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER,
         polygons: gpd.GeoDataFrame | None = None
     ) -> None:
         """
@@ -61,7 +62,7 @@ class LandCoverSolution:
         ----------
         hydromt_path : Path
             A directory to where all necessary files are stored to run wflow model
-        landcover : str = 'globcover'
+        landcover : LandcoverClassDataset = LandcoverClassDataset.GLOBCOVER
             Name of land cover dataset. Default is 'globcover'
         scenario_and_id_folder : Path
             Directory to the scenario folder name with ID
@@ -100,13 +101,7 @@ class LandCoverSolution:
             polygons["landcover"] = polygons["landcover_name"].map(LCDB_CLASSES)
 
         # Create rasterization shapes
-        shapes = [
-            (geom, value)
-            for geom, value in zip(
-                polygons.geometry,
-                polygons["landcover"]
-            )
-        ]
+        shapes = list(zip(polygons.geometry, polygons["landcover"]))
 
         # Rasterize all polygons at once
         polygon_raster = rasterize(
@@ -133,14 +128,8 @@ class LandCoverSolution:
             Directory to the modified landcover.
         """
         # Set up land cover features based on chosen land cover
-        if self.landcover.startswith('globcover'):
-            original_landcover = 'original_globcover.tif'
-            crs = 4326
-            folder_landcover = 'globcover'
-        else:
-            original_landcover = 'original_lcdb.tif'
-            crs = 2193
-            folder_landcover = 'lcdb'
+        original_landcover = f'original_{self.landcover}.tif'
+        crs = 4326 if self.landcover == LandcoverClassDataset.GLOBCOVER else 2193
 
         # Read current land cover data
         with rxr.open_rasterio(self.hydromt_path / original_landcover) as current_landcover:
@@ -157,11 +146,11 @@ class LandCoverSolution:
         )
 
         # self.hydromt_path may not be writable on linux, so write to self.hydro_combination_path
-        globcover_dir = self.scenario_and_id_folder / 'hydrological_process' / folder_landcover
+        globcover_dir = self.scenario_and_id_folder / 'hydrological_process' / self.landcover
         globcover_dir.mkdir(parents=True, exist_ok=True)
 
         # Set up the path for new land cover with scenario and ID
-        output_path = globcover_dir / f"{folder_landcover}_{self.scenario_and_id_folder.name}.tif"
+        output_path = globcover_dir / f"{self.landcover}_{self.scenario_and_id_folder.name}.tif"
 
         # Write out new land cover
         modified_landcover.rio.to_raster(


### PR DESCRIPTION
I began this work for #171 but split it into this PR to make that one smaller.
Blocks #171 

This work also includes #170 so I recommend doing that PR first if you want a smaller PR.
Blocked by: #170 

## Context:
### `LandcoverClassDataset`
Earlier versions of the code (Between #81 and #108) used the `self.landcover` parameter passed around as both a `str` representing the choice between using LCDB or Globcover, and also as a `Path` to the specific mapping file.

This was resolved by #108 so that it is just the first option.

I want to further improve clarity with typing so it can't be confused with a Path and does not change during the pipeline, by making it a StrEnum (`LandcoverClassDataset`).
